### PR TITLE
feat: suppliers payout, receipt lightbox & payment fixes

### DIFF
--- a/src/components/admin/payments/PaymentHistory.jsx
+++ b/src/components/admin/payments/PaymentHistory.jsx
@@ -21,6 +21,7 @@ import {
 } from '@mui/material';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import { format } from 'date-fns';
+import ReceiptLightbox from '../../common/ReceiptLightbox';
 import { es } from 'date-fns/locale';
 import api from '../../../utils/api';
 import useDeviceDetection from '../../../hooks/useDeviceDetection';
@@ -30,7 +31,8 @@ const PaymentHistory = ({ payments = [], reservationId }) => {
     const [loadedPayments, setLoadedPayments] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
-    const [hasLoaded, setHasLoaded] = useState(false); // Estado para controlar si ya se cargaron los datos
+    const [hasLoaded, setHasLoaded] = useState(false);
+    const [lightboxImage, setLightboxImage] = useState(null);
 
     // Cargar pagos directamente desde la API si se proporciona un ID de reserva
     useEffect(() => {
@@ -151,17 +153,14 @@ const PaymentHistory = ({ payments = [], reservationId }) => {
                             {payment.receiptImage && (
                                 <>
                                     <Divider sx={{ my: 1, borderColor: '#555' }} />
-                                    <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                                         <Typography variant="subtitle2" sx={{ color: '#bbb' }}>
                                             Receipt
                                         </Typography>
                                         <Typography
-                                            component="a"
-                                            href={payment.receiptImage}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
                                             variant="body2"
-                                            sx={{ color: '#90caf9' }}
+                                            onClick={() => setLightboxImage(payment.receiptImage)}
+                                            sx={{ color: '#90caf9', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
                                         >
                                             View
                                         </Typography>
@@ -176,6 +175,12 @@ const PaymentHistory = ({ payments = [], reservationId }) => {
     };
 
     return (
+        <>
+        <ReceiptLightbox
+            open={!!lightboxImage}
+            onClose={() => setLightboxImage(null)}
+            images={lightboxImage ? [lightboxImage] : []}
+        />
         <Card sx={{ bgcolor: '#2a2a2a', borderRadius: 2, mt: 3 }}>
             <CardContent sx={{ p: isMobile ? 2 : 3 }}>
                 <Typography variant="h6" sx={{ mb: 2, color: '#fff', fontWeight: 600 }}>
@@ -260,13 +265,10 @@ const PaymentHistory = ({ payments = [], reservationId }) => {
                                             <Tooltip title="View receipt">
                                                 <IconButton
                                                     size="small"
-                                                    component="a"
-                                                    href={payment.receiptImage}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
+                                                    onClick={() => setLightboxImage(payment.receiptImage)}
                                                     sx={{ color: '#90caf9' }}
                                                 >
-                                                    <ReceiptLongIcon fontSize="small" />
+                                                    <ReceiptLongIcon fontSize="medium" />
                                                 </IconButton>
                                             </Tooltip>
                                         ) : (
@@ -281,6 +283,7 @@ const PaymentHistory = ({ payments = [], reservationId }) => {
             )}
             </CardContent>
         </Card>
+        </>
     );
 };
 

--- a/src/components/admin/suppliers/SupplierPayoutSection.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutSection.jsx
@@ -14,7 +14,6 @@ import {
     Close as CloseIcon,
     Edit as EditIcon,
     Image as ImageIcon,
-    LinkOff as UnassignIcon,
 } from '@mui/icons-material';
 import { format } from 'date-fns';
 import supplierService from '../../../services/supplierService';
@@ -338,11 +337,14 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                 )}
 
                 {assignment && (
-                    <Tooltip title="Unassign supplier">
-                        <IconButton size="small" onClick={handleUnassign} sx={{ color: '#555', '&:hover': { color: '#f44' } }}>
-                            <UnassignIcon fontSize="small" />
-                        </IconButton>
-                    </Tooltip>
+                    <Button
+                        size="small"
+                        onClick={handleUnassign}
+                        sx={{ whiteSpace: 'nowrap', minWidth: 84, color: '#888', borderColor: '#444', textTransform: 'none', '&:hover': { color: '#f44336', borderColor: '#f44336' } }}
+                        variant="outlined"
+                    >
+                        Unassign
+                    </Button>
                 )}
             </Box>
 

--- a/src/components/admin/suppliers/SupplierPayoutSection.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutSection.jsx
@@ -21,6 +21,7 @@ import supplierService from '../../../services/supplierService';
 import { createSupplier, fetchAllSuppliers, selectAllSuppliers } from '../../../redux/supplierSlice';
 import { useToast } from '../../../hooks/useToast';
 import ToastNotification from '../../common/ToastNotification';
+import ReceiptLightbox from '../../common/ReceiptLightbox';
 
 // ─── constants ────────────────────────────────────────────────────────────────
 const PAYMENT_TERMS_OPTIONS = [
@@ -106,12 +107,14 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
     // assign form
     const [selectedSupplierId, setSelectedSupplierId] = useState('');
     const [payoutPerNight, setPayoutPerNight] = useState('');
+    const [cleaningFee, setCleaningFee] = useState('');
     const [paymentTerms, setPaymentTerms] = useState('Within 48h after check-out');
     const [assigning, setAssigning] = useState(false);
 
     // edit terms
     const [editingTerms, setEditingTerms] = useState(false);
     const [editPayout, setEditPayout] = useState('');
+    const [editCleaningFee, setEditCleaningFee] = useState('');
     const [editTerms, setEditTerms] = useState('');
     const [savingTerms, setSavingTerms] = useState(false);
 
@@ -132,6 +135,11 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
 
     const fileInputRef = useRef(null);
     const cameraInputRef = useRef(null);
+
+    // lightbox
+    const [lightbox, setLightbox] = useState({ open: false, images: [], index: 0 });
+    const openLightbox = (images, index = 0) => setLightbox({ open: true, images, index });
+    const closeLightbox = () => setLightbox(prev => ({ ...prev, open: false }));
 
     // ── load ───────────────────────────────────────────────────────────────────
     useEffect(() => { dispatch(fetchAllSuppliers()); }, [dispatch]);
@@ -168,11 +176,10 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
             const data = await supplierService.assignSupplier(reservationId, {
                 supplier_id: Number(selectedSupplierId),
                 payout_per_night: Number(payoutPerNight),
+                cleaning_fee: cleaningFee ? Number(cleaningFee) : 0,
                 payment_terms: paymentTerms || undefined,
             });
             setAssignment(data);
-            // Sync the reservation's supplier_status field so the badge reflects reality
-            await supplierService.updateSupplierStatus(reservationId, 'confirmed');
             success('Supplier assigned');
         } catch (e) {
             error(typeof e === 'string' ? e : 'Error assigning supplier');
@@ -184,11 +191,11 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
     const handleUnassign = async () => {
         try {
             await supplierService.unassignSupplier(reservationId);
-            await supplierService.updateSupplierStatus(reservationId, 'unassigned');
             setAssignment(null);
             setPayments([]);
             setSelectedSupplierId('');
             setPayoutPerNight('');
+            setCleaningFee('');
             success('Supplier unassigned');
         } catch (e) {
             error(typeof e === 'string' ? e : 'Error unassigning supplier');
@@ -198,6 +205,7 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
     // ── handlers: edit terms ───────────────────────────────────────────────────
     const handleStartEditTerms = () => {
         setEditPayout(String(assignment.payout_per_night));
+        setEditCleaningFee(String(assignment.cleaning_fee ?? 0));
         setEditTerms(assignment.payment_terms || '');
         setEditingTerms(true);
     };
@@ -207,6 +215,7 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
         try {
             const data = await supplierService.updateSupplierTerms(reservationId, {
                 payout_per_night: Number(editPayout),
+                cleaning_fee: editCleaningFee ? Number(editCleaningFee) : 0,
                 payment_terms: editTerms,
             });
             setAssignment(data);
@@ -348,18 +357,26 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                     {assignment && !editingTerms && (
                         <>
                             <Grid container spacing={1.5} sx={{ mb: 1.5 }}>
-                                <Grid item xs={5}>
+                                <Grid item xs={4}>
                                     <Box sx={{ bgcolor: '#252525', border: '1px solid #2e2e2e', borderRadius: 1, p: 1.5 }}>
-                                        <Typography sx={{ fontSize: '0.65rem', color: '#555', mb: 0.3 }}>Payout per Night</Typography>
+                                        <Typography sx={{ fontSize: '0.65rem', color: '#555', mb: 0.3 }}>Payout / Night</Typography>
                                         <Typography sx={{ fontWeight: 700 }}>
                                             ${Number(assignment.payout_per_night).toFixed(2)}
                                         </Typography>
                                     </Box>
                                 </Grid>
-                                <Grid item xs={7}>
+                                <Grid item xs={4}>
+                                    <Box sx={{ bgcolor: '#252525', border: '1px solid #2e2e2e', borderRadius: 1, p: 1.5 }}>
+                                        <Typography sx={{ fontSize: '0.65rem', color: '#555', mb: 0.3 }}>Cleaning Fee</Typography>
+                                        <Typography sx={{ fontWeight: 700 }}>
+                                            ${Number(assignment.cleaning_fee ?? 0).toFixed(2)}
+                                        </Typography>
+                                    </Box>
+                                </Grid>
+                                <Grid item xs={4}>
                                     <Box sx={{ bgcolor: '#252525', border: '1px solid #2e2e2e', borderRadius: 1, p: 1.5 }}>
                                         <Typography sx={{ fontSize: '0.65rem', color: '#555', mb: 0.3 }}>Payment Terms</Typography>
-                                        <Typography sx={{ fontWeight: 700, fontSize: '0.82rem', lineHeight: 1.3 }}>
+                                        <Typography sx={{ fontWeight: 700, fontSize: '0.72rem', lineHeight: 1.3 }}>
                                             {assignment.payment_terms || '—'}
                                         </Typography>
                                     </Box>
@@ -368,17 +385,15 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
 
                             {/* Stats */}
                             <Grid container spacing={1} sx={{ mb: 1.5 }}>
-                                <Grid item xs={4}>
+                                <Grid item xs={3}>
                                     <Box sx={{ bgcolor: '#1e1e1e', border: '1px solid #272727', borderRadius: 1, p: 1 }}>
-                                        <Typography sx={{ fontSize: '0.62rem', color: '#555', mb: 0.2 }}>
-                                            {nights} × ${Number(assignment.payout_per_night).toFixed(0)}
-                                        </Typography>
+                                        <Typography sx={{ fontSize: '0.62rem', color: '#555', mb: 0.2 }}>TOTAL</Typography>
                                         <Typography sx={{ fontWeight: 700 }}>
                                             {formatCurrency(assignment.calculated?.total)}
                                         </Typography>
                                     </Box>
                                 </Grid>
-                                <Grid item xs={4}>
+                                <Grid item xs={3}>
                                     <Box sx={{ bgcolor: '#1e1e1e', border: '1px solid #272727', borderRadius: 1, p: 1 }}>
                                         <Typography sx={{ fontSize: '0.62rem', color: '#555', mb: 0.2 }}>PAID</Typography>
                                         <Typography sx={{ fontWeight: 700, color: '#4caf50' }}>
@@ -386,11 +401,19 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                                         </Typography>
                                     </Box>
                                 </Grid>
-                                <Grid item xs={4}>
+                                <Grid item xs={3}>
                                     <Box sx={{ bgcolor: '#1e1e1e', border: '1px solid #272727', borderRadius: 1, p: 1 }}>
                                         <Typography sx={{ fontSize: '0.62rem', color: '#555', mb: 0.2 }}>BALANCE</Typography>
                                         <Typography sx={{ fontWeight: 700, color: Number(assignment.calculated?.balance) > 0 ? '#f87171' : '#4caf50' }}>
                                             {formatCurrency(assignment.calculated?.balance)}
+                                        </Typography>
+                                    </Box>
+                                </Grid>
+                                <Grid item xs={3}>
+                                    <Box sx={{ bgcolor: '#1e1e1e', border: '1px solid #272727', borderRadius: 1, p: 1 }}>
+                                        <Typography sx={{ fontSize: '0.62rem', color: '#555', mb: 0.2 }}>PROFIT</Typography>
+                                        <Typography sx={{ fontWeight: 700, color: Number(assignment.calculated?.profit) >= 0 ? '#4caf50' : '#f87171' }}>
+                                            {formatCurrency(assignment.calculated?.profit)}
                                         </Typography>
                                     </Box>
                                 </Grid>
@@ -409,7 +432,7 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                     {/* Edit terms mode */}
                     {assignment && editingTerms && (
                         <Grid container spacing={1.5} sx={{ mb: 2 }}>
-                            <Grid item xs={5}>
+                            <Grid item xs={4}>
                                 <TextField
                                     label="Payout per Night" size="small" fullWidth type="number"
                                     value={editPayout} onChange={e => setEditPayout(e.target.value)}
@@ -417,7 +440,15 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                                     sx={fieldSx}
                                 />
                             </Grid>
-                            <Grid item xs={7}>
+                            <Grid item xs={4}>
+                                <TextField
+                                    label="Cleaning Fee" size="small" fullWidth type="number"
+                                    value={editCleaningFee} onChange={e => setEditCleaningFee(e.target.value)}
+                                    InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                                    sx={fieldSx}
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
                                 <FormControl fullWidth size="small">
                                     <Select value={editTerms} onChange={e => setEditTerms(e.target.value)} sx={selectSx}>
                                         {PAYMENT_TERMS_OPTIONS.map(o => <MenuItem key={o} value={o}>{o}</MenuItem>)}
@@ -441,7 +472,7 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                     {/* Assign form (no assignment yet) */}
                     {!assignment && (
                         <Grid container spacing={1.5} sx={{ mb: 2 }}>
-                            <Grid item xs={5}>
+                            <Grid item xs={4}>
                                 <TextField
                                     label="Payout per Night" size="small" fullWidth type="number"
                                     value={payoutPerNight} onChange={e => setPayoutPerNight(e.target.value)}
@@ -449,7 +480,15 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                                     sx={fieldSx}
                                 />
                             </Grid>
-                            <Grid item xs={7}>
+                            <Grid item xs={4}>
+                                <TextField
+                                    label="Cleaning Fee" size="small" fullWidth type="number"
+                                    value={cleaningFee} onChange={e => setCleaningFee(e.target.value)}
+                                    InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                                    sx={fieldSx}
+                                />
+                            </Grid>
+                            <Grid item xs={4}>
                                 <FormControl fullWidth size="small">
                                     <Select value={paymentTerms} onChange={e => setPaymentTerms(e.target.value)} sx={selectSx}>
                                         {PAYMENT_TERMS_OPTIONS.map(o => <MenuItem key={o} value={o}>{o}</MenuItem>)}
@@ -487,7 +526,7 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                                     <CheckCircleIcon sx={{ color: '#4caf50', fontSize: '1rem', mt: 0.35, flexShrink: 0 }} />
                                     <Box sx={{ flex: 1, minWidth: 0 }}>
                                         <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', textTransform: 'capitalize' }}>
-                                            {p.method.charAt(0).toUpperCase() + p.method.slice(1)} transfer
+                                            {p.method.charAt(0).toUpperCase() + p.method.slice(1)}
                                         </Typography>
                                         <Typography sx={{ fontSize: '0.73rem', color: '#555' }}>
                                             {formatPaymentDate(p.date)}{p.referenceNotes ? ` · ${p.referenceNotes}` : ''}
@@ -496,6 +535,17 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                                     <Typography sx={{ fontWeight: 600, color: '#4caf50', fontSize: '0.9rem', flexShrink: 0 }}>
                                         {formatCurrency(p.amount)}
                                     </Typography>
+                                    {p.receiptImages && p.receiptImages.length > 0 && (
+                                        <Tooltip title={`${p.receiptImages.length} receipt${p.receiptImages.length > 1 ? 's' : ''}`}>
+                                            <IconButton
+                                                size="small"
+                                                onClick={() => openLightbox(p.receiptImages, 0)}
+                                                sx={{ color: '#90caf9', p: 0.3, flexShrink: 0 }}
+                                            >
+                                                <ImageIcon sx={{ fontSize: '1.3rem' }} />
+                                            </IconButton>
+                                        </Tooltip>
+                                    )}
                                     <IconButton
                                         size="small" onClick={() => handleDeletePayment(p.id)}
                                         disabled={deletingPaymentId === p.id}
@@ -685,6 +735,12 @@ const SupplierPayoutSection = ({ reservationId, nights = 0 }) => {
                 </DialogActions>
             </Dialog>
 
+            <ReceiptLightbox
+                open={lightbox.open}
+                onClose={closeLightbox}
+                images={lightbox.images}
+                initialIndex={lightbox.index}
+            />
             <ToastNotification toast={toast} onClose={hideToast} />
         </Box>
     );

--- a/src/components/admin/suppliers/SupplierPayoutSummary.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutSummary.jsx
@@ -27,16 +27,14 @@ const SupplierPayoutSummary = ({ reservationId, nights, totalAmount }) => {
     useEffect(() => {
         if (!reservationId) return;
         let cancelled = false;
-        Promise.all([
-            supplierService.getReservationSupplier(reservationId),
-            supplierService.getSupplierPayments(reservationId),
-        ]).then(([assignment, payments]) => {
+        supplierService.getReservationSupplier(reservationId).then((assignment) => {
             if (cancelled || !assignment) return;
-            const owed = (assignment.payout_per_night ?? 0) * (nights ?? 0);
-            const paid = payments.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);
-            const balance = owed - paid;
+            const cal = assignment.calculated || {};
+            const owed = Number(cal.total ?? (assignment.payout_per_night ?? 0) * (nights ?? 0));
+            const paid = Number(cal.paid ?? 0);
+            const balance = Number(cal.balance ?? owed - paid);
+            const netMargin = Number(cal.profit ?? (Number(totalAmount) || 0) - owed);
             const clientTotal = Number(totalAmount) || 0;
-            const netMargin = clientTotal - owed;
             const marginPct = clientTotal > 0 ? (netMargin / clientTotal) * 100 : 0;
             setData({ owed, paid, balance, netMargin, marginPct });
         }).catch(() => {});

--- a/src/components/admin/suppliers/SupplierPayoutView.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutView.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
     Avatar, Box, Button, Chip, CircularProgress, Dialog, DialogActions,
-    DialogContent, DialogTitle, Divider, FormControl, LinearProgress,
+    DialogContent, DialogTitle, Divider, FormControl, IconButton, LinearProgress,
     MenuItem, Select, TextField, Tooltip, Typography,
 } from '@mui/material';
 import {
@@ -10,11 +10,13 @@ import {
     AttachFile as AttachFileIcon,
     CheckCircle as CheckCircleIcon,
     Home as HomeIcon,
+    Image as ImageIcon,
 } from '@mui/icons-material';
 import { format, parseISO } from 'date-fns';
 import supplierService from '../../../services/supplierService';
 import { useToast } from '../../../hooks/useToast';
 import ToastNotification from '../../common/ToastNotification';
+import ReceiptLightbox from '../../common/ReceiptLightbox';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 const initials = (name = '') =>
@@ -29,8 +31,10 @@ const fmtDate = (dateStr) => {
 const USD = (n) => `$${Number(n ?? 0).toFixed(2)}`;
 
 const METHOD_LABELS = {
-    cash: 'Cash', wire_transfer: 'Wire transfer', bank_transfer: 'Bank transfer',
-    check: 'Check', zelle: 'Zelle', venmo: 'Venmo', other: 'Other',
+    cash: 'Cash',
+    wire: 'Wire',
+    card: 'Card',
+    transfer: 'Transfer',
 };
 
 // ─── sub-components ───────────────────────────────────────────────────────────
@@ -55,8 +59,11 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
     const [loading, setLoading] = useState(true);
     const [dialogOpen, setDialogOpen] = useState(false);
     const [saving, setSaving] = useState(false);
-    const [form, setForm] = useState({ amount: '', method: 'wire_transfer', date: '', referenceNotes: '' });
+    const [form, setForm] = useState({ amount: '', method: 'wire', date: '', referenceNotes: '' });
     const [receiptFiles, setReceiptFiles] = useState([]);
+    const [lightbox, setLightbox] = useState({ open: false, images: [], index: 0 });
+    const openLightbox = (images, index = 0) => setLightbox({ open: true, images, index });
+    const closeLightbox = () => setLightbox(prev => ({ ...prev, open: false }));
 
     const load = async () => {
         if (!reservationId) return;
@@ -85,11 +92,12 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
     const nights = Number(reservation?.nights ?? 0);
     const totalAmount = Number(reservation?.totalAmount ?? 0);
     const payoutPerNight = Number(assignment.payout_per_night ?? 0);
-    const owed = payoutPerNight * nights;
-    const paid = payments.reduce((s, p) => s + Number(p.amount ?? 0), 0);
-    const balance = owed - paid;
+    const cal = assignment.calculated || {};
+    const owed = Number(cal.total ?? payoutPerNight * nights);
+    const paid = Number(cal.paid ?? payments.reduce((s, p) => s + Number(p.amount ?? 0), 0));
+    const balance = Number(cal.balance ?? owed - paid);
     const pct = owed > 0 ? Math.min(100, Math.round((paid / owed) * 100)) : 0;
-    const netMargin = totalAmount - owed;
+    const netMargin = Number(cal.profit ?? totalAmount - owed);
     const marginPct = totalAmount > 0 ? Math.round((netMargin / totalAmount) * 100) : 0;
 
     // badge color — usa los mismos tonos que el resto del admin
@@ -98,7 +106,7 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
 
     // ── register payment handlers ─────────────────────────────────────────────
     const handleOpenDialog = () => {
-        setForm({ amount: '', method: 'wire_transfer', date: new Date().toISOString().slice(0, 10), referenceNotes: '' });
+        setForm({ amount: '', method: 'wire', date: new Date().toISOString().slice(0, 10), referenceNotes: '' });
         setReceiptFiles([]);
         setDialogOpen(true);
     };
@@ -125,6 +133,12 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
     return (
         <>
             <ToastNotification toast={toast} />
+            <ReceiptLightbox
+                open={lightbox.open}
+                onClose={closeLightbox}
+                images={lightbox.images}
+                initialIndex={lightbox.index}
+            />
 
             <Box sx={{ mt: 3, bgcolor: '#2a2a2a', borderRadius: 2, overflow: 'hidden', border: '1px solid #444' }}>
 
@@ -284,6 +298,17 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
                                     <Typography sx={{ color: '#4caf50', fontWeight: 700, fontSize: '0.88rem', flexShrink: 0 }}>
                                         {USD(p.amount)}
                                     </Typography>
+                                    {p.receiptImages && p.receiptImages.length > 0 && (
+                                        <Tooltip title={`${p.receiptImages.length} receipt${p.receiptImages.length > 1 ? 's' : ''}`}>
+                                            <IconButton
+                                                size="small"
+                                                onClick={() => openLightbox(p.receiptImages, 0)}
+                                                sx={{ color: '#90caf9', p: 0.3, flexShrink: 0 }}
+                                            >
+                                                <ImageIcon sx={{ fontSize: '1.3rem' }} />
+                                            </IconButton>
+                                        </Tooltip>
+                                    )}
                                 </Box>
                             ))}
 

--- a/src/components/admin/suppliers/SupplierPayoutView.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutView.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
     Avatar, Box, Button, Chip, CircularProgress, Dialog, DialogActions,
     DialogContent, DialogTitle, Divider, FormControl, IconButton, LinearProgress,
@@ -65,7 +65,7 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
     const openLightbox = (images, index = 0) => setLightbox({ open: true, images, index });
     const closeLightbox = () => setLightbox(prev => ({ ...prev, open: false }));
 
-    const load = async () => {
+    const load = useCallback(async () => {
         if (!reservationId) return;
         setLoading(true);
         try {
@@ -80,9 +80,9 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [reservationId]);
 
-    useEffect(() => { load(); }, [reservationId]);
+    useEffect(() => { load(); }, [load]);
 
     if (loading) return null;
     if (!data) return null;
@@ -92,6 +92,7 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
     const nights = Number(reservation?.nights ?? 0);
     const totalAmount = Number(reservation?.totalAmount ?? 0);
     const payoutPerNight = Number(assignment.payout_per_night ?? 0);
+    const cleaningFee = Number(assignment.cleaning_fee ?? 0);
     const cal = assignment.calculated || {};
     const owed = Number(cal.total ?? payoutPerNight * nights);
     const paid = Number(cal.paid ?? payments.reduce((s, p) => s + Number(p.amount ?? 0), 0));
@@ -230,17 +231,30 @@ const SupplierPayoutView = ({ reservationId, reservation }) => {
 
                     {/* Middle — stats */}
                     <Box sx={{ flex: '1 1 260px', minWidth: 0, p: 3, borderRight: '1px solid #444' }}>
-                        <Box sx={{ mb: 2 }}>
-                            <StatLabel>Rate per night to provider</StatLabel>
-                            <StatValue color="#ff9800">{USD(payoutPerNight)}</StatValue>
-                            <Typography sx={{ fontSize: '0.75rem', color: '#888', mt: 0.3 }}>
-                                {nights} nights · {USD(owed)} total
-                            </Typography>
+                        <Box sx={{ display: 'flex', gap: 20, mb: 2 }}>
+                            <Box>
+                                <StatLabel>Rate per night</StatLabel>
+                                <StatValue color="#ff9800">{USD(payoutPerNight)}</StatValue>
+                                <Typography sx={{ fontSize: '0.75rem', color: '#888', mt: 0.3 }}>
+                                    × {nights} nights = {USD(payoutPerNight * nights)}
+                                </Typography>
+                            </Box>
+                            {cleaningFee > 0 && (
+                                <Box>
+                                    <StatLabel>Cleaning fee</StatLabel>
+                                    <StatValue color="#ff9800">{USD(cleaningFee)}</StatValue>
+                                </Box>
+                            )}
                         </Box>
 
                         <Box sx={{ mb: 2 }}>
-                            <StatLabel>Owed to provider</StatLabel>
+                            <StatLabel>Total owed to provider</StatLabel>
                             <StatValue color="#ff9800">{USD(owed)}</StatValue>
+                            {cleaningFee > 0 && (
+                                <Typography sx={{ fontSize: '0.72rem', color: '#666', mt: 0.3 }}>
+                                    {USD(payoutPerNight * nights)} + {USD(cleaningFee)} cleaning
+                                </Typography>
+                            )}
                         </Box>
 
                         <Box sx={{ mb: 2 }}>

--- a/src/components/common/ReceiptLightbox.jsx
+++ b/src/components/common/ReceiptLightbox.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Box, Dialog, DialogContent, IconButton, Typography,
+} from '@mui/material';
+import {
+    Close as CloseIcon,
+    ChevronLeft as ChevronLeftIcon,
+    ChevronRight as ChevronRightIcon,
+} from '@mui/icons-material';
+
+const ReceiptLightbox = ({ open, onClose, images = [], initialIndex = 0 }) => {
+    const [index, setIndex] = useState(initialIndex);
+
+    useEffect(() => {
+        if (open) setIndex(initialIndex);
+    }, [open, initialIndex]);
+
+    if (!images.length) return null;
+
+    const hasPrev = index > 0;
+    const hasNext = index < images.length - 1;
+
+    const handlePrev = (e) => { e.stopPropagation(); setIndex(i => i - 1); };
+    const handleNext = (e) => { e.stopPropagation(); setIndex(i => i + 1); };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'ArrowLeft' && hasPrev) setIndex(i => i - 1);
+        if (e.key === 'ArrowRight' && hasNext) setIndex(i => i + 1);
+        if (e.key === 'Escape') onClose();
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="md"
+            fullWidth
+            onKeyDown={handleKeyDown}
+            PaperProps={{
+                sx: {
+                    bgcolor: '#0d0d0d',
+                    backgroundImage: 'none',
+                    overflow: 'hidden',
+                    position: 'relative',
+                },
+            }}
+        >
+            {/* Close */}
+            <IconButton
+                onClick={onClose}
+                sx={{
+                    position: 'absolute', top: 8, right: 8, zIndex: 10,
+                    color: '#fff', bgcolor: 'rgba(0,0,0,0.5)',
+                    '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
+                }}
+            >
+                <CloseIcon />
+            </IconButton>
+
+            {/* Counter */}
+            {images.length > 1 && (
+                <Typography
+                    sx={{
+                        position: 'absolute', top: 12, left: '50%',
+                        transform: 'translateX(-50%)', zIndex: 10,
+                        color: '#ccc', fontSize: '0.8rem',
+                        bgcolor: 'rgba(0,0,0,0.5)', px: 1.5, py: 0.3, borderRadius: 2,
+                    }}
+                >
+                    {index + 1} / {images.length}
+                </Typography>
+            )}
+
+            <DialogContent sx={{ p: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 300 }}>
+                {/* Prev arrow */}
+                {hasPrev && (
+                    <IconButton
+                        onClick={handlePrev}
+                        sx={{
+                            position: 'absolute', left: 8, zIndex: 10,
+                            color: '#fff', bgcolor: 'rgba(0,0,0,0.5)',
+                            '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
+                        }}
+                    >
+                        <ChevronLeftIcon />
+                    </IconButton>
+                )}
+
+                <Box
+                    component="img"
+                    src={images[index]}
+                    alt={`Receipt ${index + 1}`}
+                    sx={{
+                        maxWidth: '100%',
+                        maxHeight: '80vh',
+                        objectFit: 'contain',
+                        display: 'block',
+                        mx: 'auto',
+                    }}
+                />
+
+                {/* Next arrow */}
+                {hasNext && (
+                    <IconButton
+                        onClick={handleNext}
+                        sx={{
+                            position: 'absolute', right: 8, zIndex: 10,
+                            color: '#fff', bgcolor: 'rgba(0,0,0,0.5)',
+                            '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
+                        }}
+                    >
+                        <ChevronRightIcon />
+                    </IconButton>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default ReceiptLightbox;

--- a/src/services/reservationPaymentsService.js
+++ b/src/services/reservationPaymentsService.js
@@ -70,20 +70,23 @@ const reservationPaymentService = {
         try {
             const { receiptImage, removeReceiptImage, ...rest } = paymentData;
 
-            if (receiptImage instanceof File || removeReceiptImage) {
+            if (receiptImage instanceof File) {
                 const form = new FormData();
                 if (rest.amount !== undefined) form.append('amount', parseFloat(rest.amount));
-                if (rest.paymentMethod) form.append('paymentMethod', rest.paymentMethod);
-                if (rest.paymentDate) form.append('paymentDate', rest.paymentDate);
-                if (rest.paymentReference) form.append('paymentReference', rest.paymentReference);
+                if (rest.payment_method) form.append('paymentMethod', rest.payment_method);
+                if (rest.payment_date) form.append('paymentDate', rest.payment_date);
+                if (rest.payment_reference) form.append('paymentReference', rest.payment_reference);
                 if (rest.notes) form.append('notes', rest.notes);
-                if (receiptImage instanceof File) form.append('receipt_image', receiptImage);
+                form.append('receipt_image', receiptImage);
                 if (removeReceiptImage) form.append('remove_receipt_image', 'true');
                 const response = await api.put(`/reservation-payments/${id}`, form);
                 return response.data;
             }
 
-            const response = await api.put(`/reservation-payments/${id}`, rest);
+            // Sin archivo nuevo: JSON (amount queda como number)
+            const body = { ...rest };
+            if (removeReceiptImage) body.remove_receipt_image = true;
+            const response = await api.put(`/reservation-payments/${id}`, body);
             return response.data;
         } catch (error) {
             throw error.response?.data?.message || 'Error updating payment';

--- a/src/services/supplierService.js
+++ b/src/services/supplierService.js
@@ -7,6 +7,7 @@ const normalizeAssignment = (data) => {
         reservationId: data.reservation_id ?? data.reservationId,
         supplier: data.supplier,
         payout_per_night: data.payout_per_night ?? data.payoutPerNight,
+        cleaning_fee: data.cleaning_fee ?? data.cleaningFee ?? 0,
         payment_terms: data.payment_terms ?? data.paymentTerms,
         calculated: data.calculated,
     };


### PR DESCRIPTION
## Summary

- **Suppliers & Payout UI**: sección completa en la vista de reserva para asignar/desasignar supplier, gestionar términos de pago (payout/night + cleaning fee), registrar pagos y ver el historial con breakdown financiero (total, paid, balance, profit)
- **ReceiptLightbox**: componente reutilizable para ver imágenes de recibos dentro de la app (modal MUI) con navegación multi-imagen (flechas, contador, teclado ←/→/Esc)
- **Viewing de recibos en pagos de clientes** (`PaymentHistory`): ícono para abrir recibo en lightbox en vez de nueva pestaña
- **Fix métodos de pago supplier**: corrige valores inválidos (`wire_transfer` → `wire`, elimina `bank_transfer`, `zelle`, etc.)
- **Fix `updatePayment` service**: evita usar FormData cuando no hay archivo nuevo, para que `amount` llegue como number al backend (Zod `z.number()` rechazaba el string de FormData)
- **Fix `react-hooks/exhaustive-deps`**: `load()` envuelta en `useCallback` en `SupplierPayoutView`
- **UI tweaks**: botón "Unassign" visible en lugar de ícono oculto; cleaning fee mostrada junto al rate per night

## Test plan

- [x] Asignar supplier a una reserva → `supplier_status` cambia a `confirmed`
- [x] Editar términos (payout/night, cleaning fee, payment terms)
- [x] Registrar pago de supplier con y sin imagen de recibo
- [x] Ver recibo en lightbox (navegar si hay múltiples)
- [x] Desasignar supplier → `supplier_status` vuelve a `unassigned`
- [x] Editar pago de cliente con recibo existente + marcar "Remove receipt" → sin error de validación
- [x] Verificar breakdown de totales: rate × nights + cleaning fee = total owed

🤖 Generated with [Claude Code](https://claude.com/claude-code)