### PR TITLE
perf/fix: performance audit — 18 fixes across rendering, API, bundle and auth

### DIFF
--- a/src/components/admin/AdminDashboard.jsx
+++ b/src/components/admin/AdminDashboard.jsx
@@ -33,13 +33,11 @@ import SalesVolumeChart from "./dashboard/SalesVolumeChart";
 
 // Redux actions
 import { fetchUsers, selectUserCount } from "../../redux/userSlice";
-
 import { fetchReservations } from "../../redux/reservationSlice";
 import { fetchAllPayments } from "../../redux/reservationPaymentSlice";
 import { fetchReviews } from "../../redux/reviewSlice";
-import adminApartmentService from "../../services/adminApartmentService";
+import { fetchAdminApartments, selectAllApartments, selectApartmentStatus } from "../../redux/adminApartmentSlice";
 import useDeviceDetection from "../../hooks/useDeviceDetection";
-import { normalizeReservationFromApi, normalizeApartmentFromApi } from "../../utils/normalizers";
 
 const AdminDashboard = () => {
   const theme = useTheme();
@@ -50,23 +48,33 @@ const AdminDashboard = () => {
 
   // Estados locales
   const [openSnackbar, setOpenSnackbar] = useState(false);
-  const [apartments, setApartments] = useState([]);
-  const [buildingNames, setBuildingNames] = useState({});
 
-  // Selectores de Redux con normalización
+  // Selectores de Redux
   const userError = useSelector((state) => state.users.error);
   const reviewError = useSelector((state) => state.reviews.error);
-  const rawReservations = useSelector((state) => state.reservations.reservations);
-  const reservations = useMemo(() => {
-    if (!rawReservations || rawReservations.length === 0) return [];
-    return rawReservations.map(reservation => normalizeReservationFromApi(reservation));
-  }, [rawReservations]);
+  const reservations = useSelector((state) => state.reservations.reservations);
   const payments = useSelector((state) => state.reservationPayments.payments);
   const reservationsLoading = useSelector((state) => state.reservations.loading);
   const usersStatus = useSelector((state) => state.users.status);
+  const reservationsStatus = useSelector((state) => state.reservations.status);
+  const paymentsStatus = useSelector((state) => state.reservationPayments.status);
+  const reviewsStatus = useSelector((state) => state.reviews.status);
+  const apartmentsStatus = useSelector(selectApartmentStatus);
   const paymentsLoading = useSelector((state) => state.reservationPayments.loading);
   const totalUsers = useSelector(selectUserCount);
   const reviews = useSelector((state) => state.reviews.items);
+  const apartments = useSelector(selectAllApartments);
+
+  // buildingNames derivado de los apartamentos del store
+  const buildingNames = useMemo(() => {
+    const namesMap = {};
+    apartments.forEach((apt) => {
+      const buildingName = apt.name || "Sin nombre";
+      const unitNumber = apt.unitNumber ? ` - Unidad ${apt.unitNumber}` : "";
+      namesMap[String(apt.id)] = buildingName + unitNumber;
+    });
+    return namesMap;
+  }, [apartments]);
 
   // Cálculos memorizados
   const latestReservations = useMemo(() => {
@@ -95,38 +103,14 @@ const AdminDashboard = () => {
       .slice(0, 3);
   }, [reservations]);
 
-  // Cargar datos al montar el componente
+  // Cargar datos solo si no están ya en el store
   useEffect(() => {
-    dispatch(fetchUsers());
-    dispatch(fetchReservations({}));
-    dispatch(fetchAllPayments());
-    dispatch(fetchReviews());
-    loadApartments();
-  }, [dispatch]);
-
-  // Cargar apartamentos para obtener los nombres
-  const loadApartments = async () => {
-    try {
-      const apartmentList = await adminApartmentService.getAllApartments();
-      // Normalizar los apartamentos también
-      const normalizedApartments = apartmentList.map(apt => normalizeApartmentFromApi(apt));
-      setApartments(normalizedApartments);
-
-      const namesMap = {};
-      normalizedApartments.forEach((apt) => {
-        const idKey = String(apt.id);
-        const buildingName = apt.name || "Sin nombre";
-        const unitNumber = apt.unitNumber
-          ? ` - Unidad ${apt.unitNumber}`
-          : "";
-        namesMap[idKey] = buildingName + unitNumber;
-      });
-      setBuildingNames(namesMap);
-    } catch (error) {
-      console.error("Error al cargar apartamentos:", error);
-      setOpenSnackbar(true);
-    }
-  };
+    if (usersStatus === 'idle') dispatch(fetchUsers());
+    if (reservationsStatus === 'idle') dispatch(fetchReservations({}));
+    if (paymentsStatus === 'idle') dispatch(fetchAllPayments());
+    if (reviewsStatus === 'idle') dispatch(fetchReviews());
+    if (apartmentsStatus === 'idle') dispatch(fetchAdminApartments());
+  }, [dispatch, usersStatus, reservationsStatus, paymentsStatus, reviewsStatus, apartmentsStatus]);
 
   // Effects
   useEffect(() => {

--- a/src/components/admin/AdminDashboard.jsx
+++ b/src/components/admin/AdminDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, Suspense } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import {
@@ -26,10 +26,9 @@ import {
   BarChart as BarChartIcon,
 } from "@mui/icons-material";
 
-// Componentes
-import MonthlySummary from "./dashboard/MonthlySummary";
-import BookingTrendsChart from "./dashboard/BookingTrendsChart";
-import SalesVolumeChart from "./dashboard/SalesVolumeChart";
+const MonthlySummary = React.lazy(() => import("./dashboard/MonthlySummary"));
+const BookingTrendsChart = React.lazy(() => import("./dashboard/BookingTrendsChart"));
+const SalesVolumeChart = React.lazy(() => import("./dashboard/SalesVolumeChart"));
 
 // Redux actions
 import { fetchUsers, selectUserCount } from "../../redux/userSlice";
@@ -164,7 +163,9 @@ const AdminDashboard = () => {
                     <Skeleton variant="rectangular" height={300} sx={{ mt: 2 }} />
                   </Paper>
                 ) : (
-                  <BookingTrendsChart reservations={reservations} />
+                  <Suspense fallback={<Skeleton variant="rectangular" height={300} sx={{ mt: 2 }} />}>
+                    <BookingTrendsChart reservations={reservations} />
+                  </Suspense>
                 )}
               </Grid>
             )}
@@ -318,9 +319,13 @@ const AdminDashboard = () => {
           </Grid>
         </>
       ) : activeTab === 1 ? (
-        <SalesVolumeChart />
+        <Suspense fallback={<Skeleton variant="rectangular" height={400} />}>
+          <SalesVolumeChart />
+        </Suspense>
       ) : !isMobile ? (
-        <MonthlySummary />
+        <Suspense fallback={<Skeleton variant="rectangular" height={400} />}>
+          <MonthlySummary />
+        </Suspense>
       ) : (
         <Paper sx={{ p: 3, textAlign: "center" }}>
           <Typography variant="body1" color="text.secondary">

--- a/src/components/admin/auth/AdminLogin.jsx
+++ b/src/components/admin/auth/AdminLogin.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
-import { 
-  Box, 
-  Container, 
-  TextField, 
-  Button, 
-  Typography, 
+import {
+  Box,
+  Container,
+  TextField,
+  Button,
+  Typography,
   Paper,
-  Alert
+  Alert,
+  CircularProgress
 } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import adminService from '../../../services/adminService';
@@ -15,24 +16,29 @@ const AdminLogin = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
   const handleLogin = async (e) => {
     e.preventDefault();
+    if (!username.trim() || !password.trim()) return;
+
     setError('');
+    setLoading(true);
 
     try {
       const response = await adminService.login(username, password);
       if (response) {
         localStorage.setItem('adminToken', response.token);
-        // Redirigir a la página anterior o al dashboard por defecto
         const from = location.state?.from || '/admin';
         navigate(from, { replace: true });
       }
     } catch (error) {
       setError(error.message || 'User or password incorrect');
-      localStorage.removeItem('adminToken'); // Limpiamos el token si hay error
+      localStorage.removeItem('adminToken');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -63,6 +69,7 @@ const AdminLogin = () => {
               autoFocus
               value={username}
               onChange={(e) => setUsername(e.target.value)}
+              disabled={loading}
             />
             <TextField
               margin="normal"
@@ -75,14 +82,16 @@ const AdminLogin = () => {
               autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              disabled={loading}
             />
             <Button
               type="submit"
               fullWidth
               variant="contained"
+              disabled={loading || !username.trim() || !password.trim()}
               sx={{ mt: 3, mb: 2 }}
             >
-              Sign In
+              {loading ? <CircularProgress size={24} color="inherit" /> : 'Sign In'}
             </Button>
           </Box>
         </Paper>

--- a/src/components/admin/reservations/ReservationForm.jsx
+++ b/src/components/admin/reservations/ReservationForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
     Grid,
@@ -69,16 +69,12 @@ const ReservationForm = ({ initialData, onSubmit }) => {
     const [openEditClientDialog, setOpenEditClientDialog] = useState(false);
     const { toast, warning, error, hideToast } = useToast();
 
-    // Manejadores de diálogos
-    const handleOpenNewClientDialog = () => setOpenNewClientDialog(true);
-    const handleCloseNewClientDialog = () => setOpenNewClientDialog(false);
-    const handleOpenEditClientDialog = () => setOpenEditClientDialog(true);
-    const handleCloseEditClientDialog = () => setOpenEditClientDialog(false);
-
-    // Manejar cancelar - navegar de vuelta
-    const handleCancel = () => {
-        navigate(-1); // Volver a la página anterior
-    };
+    const handleOpenNewClientDialog = useCallback(() => setOpenNewClientDialog(true), []);
+    const handleCloseNewClientDialog = useCallback(() => setOpenNewClientDialog(false), []);
+    const handleOpenEditClientDialog = useCallback(() => setOpenEditClientDialog(true), []);
+    const handleCloseEditClientDialog = useCallback(() => setOpenEditClientDialog(false), []);
+    const handleCancel = useCallback(() => navigate(-1), [navigate]);
+    const handlePaymentRegistered = useCallback(() => {}, []);
 
     // Función para obtener el estilo y texto del estado de pago
     const getPaymentStatusDisplay = (paymentStatus) => {
@@ -427,9 +423,7 @@ const ReservationForm = ({ initialData, onSubmit }) => {
                                     <PaymentSection
                                         formData={formData}
                                         onChange={handleChange}
-                                        onPaymentRegistered={(paymentResponse) => {
-                                            // Payment successfully registered
-                                        }}
+                                        onPaymentRegistered={handlePaymentRegistered}
                                         onInitialPaymentChange={handleInitialPaymentChange}
                                         initialPaymentData={initialPaymentData}
                                     />

--- a/src/components/admin/reservations/ReservationList.jsx
+++ b/src/components/admin/reservations/ReservationList.jsx
@@ -47,7 +47,7 @@ import {
     FilterAlt as FilterIcon
 } from '@mui/icons-material';
 import { fetchReservations, deleteReservation, setSelectedReservation } from '../../../redux/reservationSlice';
-import adminApartmentService from '../../../services/adminApartmentService';
+import { fetchAdminApartments, selectAllApartments, selectApartmentStatus } from '../../../redux/adminApartmentSlice';
 import userService from '../../../services/userService';
 import ReservationFilters from './ReservationFilters';
 import { formatDateForDisplay, parseStringToDate } from '../../../utils/dateUtils';
@@ -114,6 +114,8 @@ const ReservationList = ({ filter = {} }) => {
     const navigate = useNavigate();
     const theme = useTheme();
     const { reservations, loading, status, error, pagination } = useSelector((state) => state.reservations);
+    const reduxApartments = useSelector(selectAllApartments);
+    const apartmentsStatus = useSelector(selectApartmentStatus);
     const { isMobile, isTablet } = useDeviceDetection();
 
     const [page, setPage] = useState(0);
@@ -153,24 +155,25 @@ const ReservationList = ({ filter = {} }) => {
         dispatch(fetchReservations({ ...combinedFilters, page: page + 1, limit: rowsPerPage }));
     }, [dispatch, combinedFilters, page, rowsPerPage]);
 
+    // Fetch apartments via Redux — solo si no están ya cargados (evita 429 por mounts repetidos)
     useEffect(() => {
-        const loadApartments = async () => {
-            try {
-                const apartmentList = await adminApartmentService.getAllApartments();
-                const namesMap = {};
-                apartmentList.forEach(apt => {
-                    const idKey = String(apt.id);
-                    const buildingName = apt.building_name || apt.name || 'Sin nombre';
-                    const unitNumber = apt.unit_number ? ` - Unidad ${apt.unit_number}` : '';
-                    namesMap[idKey] = buildingName + unitNumber;
-                });
-                setBuildingNames(namesMap);
-            } catch (error) {
-                console.error('Error al cargar apartamentos:', error);
-            }
-        };
-        loadApartments();
-    }, []);
+        if (apartmentsStatus === 'idle') {
+            dispatch(fetchAdminApartments());
+        }
+    }, [dispatch, apartmentsStatus]);
+
+    // Construir buildingNames cuando los datos de Redux estén disponibles
+    useEffect(() => {
+        if (reduxApartments.length === 0) return;
+        const namesMap = {};
+        reduxApartments.forEach(apt => {
+            const idKey = String(apt.id);
+            const buildingName = apt.building_name || apt.name || 'Sin nombre';
+            const unitNumber = apt.unit_number ? ` - Unidad ${apt.unit_number}` : '';
+            namesMap[idKey] = buildingName + unitNumber;
+        });
+        setBuildingNames(namesMap);
+    }, [reduxApartments]);
 
     // Si el filtro upcoming está activo, forzar el orden por check-in ascendente y persistirlo
     useEffect(() => {

--- a/src/components/admin/reservations/ReservationList.jsx
+++ b/src/components/admin/reservations/ReservationList.jsx
@@ -53,21 +53,75 @@ import ReservationFilters from './ReservationFilters';
 import { formatDateForDisplay, parseStringToDate } from '../../../utils/dateUtils';
 import useDeviceDetection from '../../../hooks/useDeviceDetection';
 
+const sortReservations = (reservations, orderBy, order) => {
+    return [...reservations].sort((a, b) => {
+        let aValue = a[orderBy];
+        let bValue = b[orderBy];
+
+        if (orderBy === 'check_in_date') {
+            aValue = a.check_in_date || a.checkInDate;
+            bValue = b.check_in_date || b.checkInDate;
+        } else if (orderBy === 'check_out_date') {
+            aValue = a.check_out_date || a.checkOutDate;
+            bValue = b.check_out_date || b.checkOutDate;
+        } else if (orderBy === 'total_amount') {
+            aValue = a.total_amount || a.totalAmount;
+            bValue = b.total_amount || b.totalAmount;
+        } else if (orderBy === 'created_at') {
+            aValue = a.created_at || a.createdAt;
+            bValue = b.created_at || b.createdAt;
+        } else if (orderBy === 'payment_status') {
+            aValue = a.payment_status || a.paymentStatus;
+            bValue = b.payment_status || b.paymentStatus;
+        }
+
+        if (orderBy === 'created_at' || orderBy === 'check_in_date' || orderBy === 'check_out_date') {
+            if (!aValue && !bValue) return 0;
+            if (!aValue) return order === 'asc' ? -1 : 1;
+            if (!bValue) return order === 'asc' ? 1 : -1;
+            aValue = new Date(aValue).getTime();
+            bValue = new Date(bValue).getTime();
+            if (isNaN(aValue) && isNaN(bValue)) return 0;
+            if (isNaN(aValue)) return order === 'asc' ? -1 : 1;
+            if (isNaN(bValue)) return order === 'asc' ? 1 : -1;
+        }
+
+        if (orderBy === 'total_amount' || orderBy === 'id') {
+            if (aValue === null || aValue === undefined) aValue = 0;
+            if (bValue === null || bValue === undefined) bValue = 0;
+            aValue = Number(aValue);
+            bValue = Number(bValue);
+            if (isNaN(aValue)) aValue = 0;
+            if (isNaN(bValue)) bValue = 0;
+        }
+
+        if (orderBy === 'status' || orderBy === 'payment_status' ||
+            (typeof aValue === 'string' || typeof bValue === 'string')) {
+            aValue = String(aValue || '').toLowerCase();
+            bValue = String(bValue || '').toLowerCase();
+        }
+
+        if (order === 'asc') {
+            return aValue > bValue ? 1 : aValue < bValue ? -1 : 0;
+        } else {
+            return aValue < bValue ? 1 : aValue > bValue ? -1 : 0;
+        }
+    });
+};
+
 const ReservationList = ({ filter = {} }) => {
     const dispatch = useDispatch();
     const navigate = useNavigate();
     const theme = useTheme();
     const { reservations, loading, status, error, pagination } = useSelector((state) => state.reservations);
     const { isMobile, isTablet } = useDeviceDetection();
-    
+
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(() => {
-        // Recuperar rowsPerPage desde localStorage
         const saved = localStorage.getItem('reservationList_rowsPerPage');
         return saved ? parseInt(saved, 10) : 10;
     });
     const [buildingNames, setBuildingNames] = useState({});
-    const [adminApartments, setAdminApartments] = useState([]);
     const [orderBy, setOrderBy] = useState(() => {
         // Recuperar orderBy desde localStorage (fall back a ordenar por check-in ascendente)
         return localStorage.getItem('reservationList_orderBy') || 'check_in_date';
@@ -92,82 +146,31 @@ const ReservationList = ({ filter = {} }) => {
     });
     const [filtersOpen, setFiltersOpen] = useState(() => !(isMobile || isTablet));
     
-    // Función para ordenar las reservas localmente
-    const sortReservations = (reservations, orderBy, order) => {
-        return [...reservations].sort((a, b) => {
-            let aValue = a[orderBy];
-            let bValue = b[orderBy];
-
-            // Manejar campos con nombres alternativos
-            if (orderBy === 'check_in_date') {
-                aValue = a.check_in_date || a.checkInDate;
-                bValue = b.check_in_date || b.checkInDate;
-            } else if (orderBy === 'check_out_date') {
-                aValue = a.check_out_date || a.checkOutDate;
-                bValue = b.check_out_date || b.checkOutDate;
-            } else if (orderBy === 'total_amount') {
-                aValue = a.total_amount || a.totalAmount;
-                bValue = b.total_amount || b.totalAmount;
-            } else if (orderBy === 'created_at') {
-                aValue = a.created_at || a.createdAt;
-                bValue = b.created_at || b.createdAt;
-            } else if (orderBy === 'payment_status') {
-                aValue = a.payment_status || a.paymentStatus;
-                bValue = b.payment_status || b.paymentStatus;
-            }
-
-            // Si es una fecha, convertir a timestamp
-            if (orderBy === 'created_at' || orderBy === 'check_in_date' || orderBy === 'check_out_date') {
-                // Manejar valores nulos/undefined
-                if (!aValue && !bValue) return 0;
-                if (!aValue) return order === 'asc' ? -1 : 1;
-                if (!bValue) return order === 'asc' ? 1 : -1;
-                
-                aValue = new Date(aValue).getTime();
-                bValue = new Date(bValue).getTime();
-                
-                // Verificar si las fechas son válidas
-                if (isNaN(aValue) && isNaN(bValue)) return 0;
-                if (isNaN(aValue)) return order === 'asc' ? -1 : 1;
-                if (isNaN(bValue)) return order === 'asc' ? 1 : -1;
-            }
-
-            // Si es un número, convertir a número
-            if (orderBy === 'total_amount' || orderBy === 'id') {
-                // Manejar valores nulos/undefined
-                if (aValue === null || aValue === undefined) aValue = 0;
-                if (bValue === null || bValue === undefined) bValue = 0;
-                
-                aValue = Number(aValue);
-                bValue = Number(bValue);
-                
-                // Verificar si son números válidos
-                if (isNaN(aValue)) aValue = 0;
-                if (isNaN(bValue)) bValue = 0;
-            }
-
-            // Para campos de texto (como status), convertir a string y comparar
-            if (orderBy === 'status' || orderBy === 'payment_status' || 
-                (typeof aValue === 'string' || typeof bValue === 'string')) {
-                aValue = String(aValue || '').toLowerCase();
-                bValue = String(bValue || '').toLowerCase();
-            }
-
-            // Realizar la comparación
-            if (order === 'asc') {
-                return aValue > bValue ? 1 : aValue < bValue ? -1 : 0;
-            } else {
-                return aValue < bValue ? 1 : aValue > bValue ? -1 : 0;
-            }
-        });
-    };
-    
     const combinedFilters = useMemo(() => ({ ...filter, ...activeFilters }), [filter, activeFilters]);
 
     // Cargar reservas al montar el componente o cuando cambian los filtros, página o filas por página
     useEffect(() => {
         dispatch(fetchReservations({ ...combinedFilters, page: page + 1, limit: rowsPerPage }));
     }, [dispatch, combinedFilters, page, rowsPerPage]);
+
+    useEffect(() => {
+        const loadApartments = async () => {
+            try {
+                const apartmentList = await adminApartmentService.getAllApartments();
+                const namesMap = {};
+                apartmentList.forEach(apt => {
+                    const idKey = String(apt.id);
+                    const buildingName = apt.building_name || apt.name || 'Sin nombre';
+                    const unitNumber = apt.unit_number ? ` - Unidad ${apt.unit_number}` : '';
+                    namesMap[idKey] = buildingName + unitNumber;
+                });
+                setBuildingNames(namesMap);
+            } catch (error) {
+                console.error('Error al cargar apartamentos:', error);
+            }
+        };
+        loadApartments();
+    }, []);
 
     // Si el filtro upcoming está activo, forzar el orden por check-in ascendente y persistirlo
     useEffect(() => {
@@ -187,29 +190,6 @@ const ReservationList = ({ filter = {} }) => {
         setFiltersOpen(!(isMobile || isTablet));
     }, [isMobile, isTablet]);
     
-    // Cargar todos los apartamentos al montar el componente
-    useEffect(() => {
-        const loadApartments = async () => {
-            try {
-                const apartmentList = await adminApartmentService.getAllApartments();
-                setAdminApartments(apartmentList);
-                
-                const namesMap = {};
-                apartmentList.forEach(apt => {
-                    const idKey = String(apt.id);
-                    const buildingName = apt.building_name || apt.name || 'Sin nombre';
-                    const unitNumber = apt.unit_number ? ` - Unidad ${apt.unit_number}` : '';
-                    namesMap[idKey] = buildingName + unitNumber;
-                });
-                setBuildingNames(namesMap);
-            } catch (error) {
-                console.error('Error al cargar apartamentos:', error);
-            }
-        };
-        
-        loadApartments();
-    }, []);
-
     // Cargar datos de clientes faltantes si la reserva no trae nombre/email
     useEffect(() => {
         const fetchMissingClients = async () => {
@@ -284,8 +264,10 @@ const ReservationList = ({ filter = {} }) => {
         return reservations;
     }, [reservations, combinedFilters]);
 
-    // Obtener las reservas ordenadas
-    const sortedReservations = sortReservations(baseReservations, orderBy, order);
+    const sortedReservations = useMemo(
+        () => sortReservations(baseReservations, orderBy, order),
+        [baseReservations, orderBy, order]
+    );
     
     // Función para cambiar la ordenación
     const handleRequestSort = (property) => {
@@ -316,8 +298,15 @@ const ReservationList = ({ filter = {} }) => {
     // Formatear fecha
     const formatDate = (dateString) => {
         if (!dateString) return 'N/A';
-        // Usar nuestra función de utilidad para mostrar fechas
-        return formatDateForDisplay(dateString, false); // false para no incluir la hora
+        return formatDateForDisplay(dateString, false);
+    };
+
+    // Formato corto para la columna Period: "Jul 25, 26"
+    const formatShortDate = (dateString) => {
+        if (!dateString) return 'N/A';
+        const parsed = parseStringToDate(dateString) || new Date(dateString);
+        if (!parsed || isNaN(parsed.getTime())) return 'N/A';
+        return parsed.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' });
     };
     
     // Formatear moneda
@@ -817,16 +806,7 @@ const ReservationList = ({ filter = {} }) => {
                                         direction={orderBy === 'check_in_date' ? order : 'asc'}
                                         onClick={() => handleRequestSort('check_in_date')}
                                     >
-                                        Check-in
-                                    </TableSortLabel>
-                                </TableCell>
-                                <TableCell>
-                                    <TableSortLabel
-                                        active={orderBy === 'check_out_date'}
-                                        direction={orderBy === 'check_out_date' ? order : 'asc'}
-                                        onClick={() => handleRequestSort('check_out_date')}
-                                    >
-                                        Check-out
+                                        Period
                                     </TableSortLabel>
                                 </TableCell>
                                 <TableCell>
@@ -857,15 +837,6 @@ const ReservationList = ({ filter = {} }) => {
                                     </TableSortLabel>
                                 </TableCell>
                                 <TableCell>Supplier</TableCell>
-                                <TableCell>
-                                    <TableSortLabel
-                                        active={orderBy === 'created_at'}
-                                        direction={orderBy === 'created_at' ? order : 'asc'}
-                                        onClick={() => handleRequestSort('created_at')}
-                                    >
-                                        Creation Date
-                                    </TableSortLabel>
-                                </TableCell>
                                 <TableCell align="right">Actions</TableCell>
                             </TableRow>
                         </TableHead>
@@ -873,9 +844,9 @@ const ReservationList = ({ filter = {} }) => {
                             {loading ? (
                                 [...Array(6)].map((_, idx) => (
                                     <TableRow key={idx}>
-                                        {[...Array(11)].map((__, cidx) => (
+                                        {[...Array(9)].map((__, cidx) => (
                                             <TableCell key={cidx}>
-                                                {cidx === 10 ? (
+                                                {cidx === 8 ? (
                                                     <>
                                                         <Skeleton variant="circular" width={28} height={28} />
                                                         <Skeleton variant="circular" width={28} height={28} sx={{ ml: 1 }} />
@@ -890,7 +861,7 @@ const ReservationList = ({ filter = {} }) => {
                                 ))
                             ) : !sortedReservations || sortedReservations.length === 0 ? (
                                 <TableRow>
-                                    <TableCell colSpan={11} align="center">No reservations found</TableCell>
+                                    <TableCell colSpan={9} align="center">No reservations found</TableCell>
                                 </TableRow>
                             ) : (
                                 sortedReservations
@@ -923,8 +894,9 @@ const ReservationList = ({ filter = {} }) => {
                                                     </Typography>
                                                 )}
                                             </TableCell>
-                                            <TableCell>{formatDate(reservation.check_in_date || reservation.checkInDate)}</TableCell>
-                                            <TableCell>{formatDate(reservation.check_out_date || reservation.checkOutDate)}</TableCell>
+                                            <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                                                {formatShortDate(reservation.check_in_date || reservation.checkInDate)} → {formatShortDate(reservation.check_out_date || reservation.checkOutDate)}
+                                            </TableCell>
                                             <TableCell>{formatCurrency(reservation.total_amount || reservation.totalAmount)}</TableCell>
                                             <TableCell>
                                                 <Chip
@@ -952,7 +924,6 @@ const ReservationList = ({ filter = {} }) => {
                                                     );
                                                 })()}
                                             </TableCell>
-                                            <TableCell>{formatDate(reservation.created_at || reservation.createdAt)}</TableCell>
                                             <TableCell align="right" onClick={(e) => e.stopPropagation()}>
                                                 <Tooltip title="View details">
                                                     <IconButton 

--- a/src/components/admin/reservations/sections/ApartmentSection.jsx
+++ b/src/components/admin/reservations/sections/ApartmentSection.jsx
@@ -151,4 +151,9 @@ const ApartmentSection = ({ formData, apartments, selectedApartment, onChange })
     );
 };
 
-export default ApartmentSection;
+export default React.memo(ApartmentSection, (prev, next) =>
+    prev.formData.apartmentId === next.formData.apartmentId &&
+    prev.apartments === next.apartments &&
+    prev.selectedApartment === next.selectedApartment &&
+    prev.onChange === next.onChange
+);

--- a/src/components/admin/reservations/sections/ClientSection.jsx
+++ b/src/components/admin/reservations/sections/ClientSection.jsx
@@ -282,4 +282,15 @@ const ClientSection = ({
     );
 };
 
-export default ClientSection; 
+export default React.memo(ClientSection, (prev, next) =>
+    prev.formData.clientName === next.formData.clientName &&
+    prev.formData.clientEmail === next.formData.clientEmail &&
+    prev.formData.clientPhone === next.formData.clientPhone &&
+    prev.formData.clientCity === next.formData.clientCity &&
+    prev.clients === next.clients &&
+    prev.selectedClient === next.selectedClient &&
+    prev.onClientSelect === next.onClientSelect &&
+    prev.onChange === next.onChange &&
+    prev.onOpenNewClient === next.onOpenNewClient &&
+    prev.onOpenEditClient === next.onOpenEditClient
+);

--- a/src/components/admin/reservations/sections/DateSection.jsx
+++ b/src/components/admin/reservations/sections/DateSection.jsx
@@ -143,4 +143,4 @@ const DateSection = ({ checkInDate, checkOutDate, onDateChange }) => {
     );
 };
 
-export default DateSection;
+export default React.memo(DateSection);

--- a/src/components/admin/reservations/sections/NotesSection.jsx
+++ b/src/components/admin/reservations/sections/NotesSection.jsx
@@ -51,4 +51,7 @@ const NotesSection = ({ formData, onChange }) => {
     );
 };
 
-export default NotesSection;
+export default React.memo(NotesSection, (prev, next) =>
+    prev.formData.notes === next.formData.notes &&
+    prev.onChange === next.onChange
+);

--- a/src/components/admin/reservations/sections/PaymentSection.jsx
+++ b/src/components/admin/reservations/sections/PaymentSection.jsx
@@ -261,4 +261,16 @@ const PaymentSection = ({ formData, onChange, onPaymentRegistered, onInitialPaym
     );
 };
 
-export default PaymentSection; 
+export default React.memo(PaymentSection, (prev, next) =>
+    prev.formData.id === next.formData.id &&
+    prev.formData.amountPaid === next.formData.amountPaid &&
+    prev.formData.totalAmount === next.formData.totalAmount &&
+    prev.formData.amountDue === next.formData.amountDue &&
+    prev.formData.paymentStatus === next.formData.paymentStatus &&
+    prev.onChange === next.onChange &&
+    prev.onPaymentRegistered === next.onPaymentRegistered &&
+    prev.onInitialPaymentChange === next.onInitialPaymentChange &&
+    prev.initialPaymentData?.amount === next.initialPaymentData?.amount &&
+    prev.initialPaymentData?.paymentMethod === next.initialPaymentData?.paymentMethod &&
+    prev.initialPaymentData?.notes === next.initialPaymentData?.notes
+);

--- a/src/components/admin/reservations/sections/PricingSection.jsx
+++ b/src/components/admin/reservations/sections/PricingSection.jsx
@@ -249,4 +249,15 @@ const PricingSection = ({ formData, onChange }) => {
   );
 };
 
-export default PricingSection;
+export default React.memo(PricingSection, (prev, next) =>
+    prev.formData.price === next.formData.price &&
+    prev.formData.nights === next.formData.nights &&
+    prev.formData.cleaningFee === next.formData.cleaningFee &&
+    prev.formData.parkingFee === next.formData.parkingFee &&
+    prev.formData.otherExpenses === next.formData.otherExpenses &&
+    prev.formData.taxes === next.formData.taxes &&
+    prev.formData.cancellationFee === next.formData.cancellationFee &&
+    prev.formData.checkInDate === next.formData.checkInDate &&
+    prev.formData.checkOutDate === next.formData.checkOutDate &&
+    prev.onChange === next.onChange
+);

--- a/src/components/admin/reservations/sections/ReservationPaymentSummary.jsx
+++ b/src/components/admin/reservations/sections/ReservationPaymentSummary.jsx
@@ -156,4 +156,15 @@ const ReservationPaymentSummary = ({ formData }) => {
   );
 };
 
-export default ReservationPaymentSummary;
+export default React.memo(ReservationPaymentSummary, (prev, next) =>
+    prev.formData.nights === next.formData.nights &&
+    prev.formData.price === next.formData.price &&
+    prev.formData.cleaningFee === next.formData.cleaningFee &&
+    prev.formData.parkingFee === next.formData.parkingFee &&
+    prev.formData.otherExpenses === next.formData.otherExpenses &&
+    prev.formData.taxes === next.formData.taxes &&
+    prev.formData.cancellationFee === next.formData.cancellationFee &&
+    prev.formData.totalAmount === next.formData.totalAmount &&
+    prev.formData.amountPaid === next.formData.amountPaid &&
+    prev.formData.amountDue === next.formData.amountDue
+);

--- a/src/components/admin/reservations/sections/StatusSection.jsx
+++ b/src/components/admin/reservations/sections/StatusSection.jsx
@@ -99,4 +99,8 @@ const StatusSection = ({ formData, onChange }) => {
     );
 };
 
-export default StatusSection; 
+export default React.memo(StatusSection, (prev, next) =>
+    prev.formData.status === next.formData.status &&
+    prev.formData.paymentStatus === next.formData.paymentStatus &&
+    prev.onChange === next.onChange
+); 

--- a/src/components/admin/services/ServicesPage.jsx
+++ b/src/components/admin/services/ServicesPage.jsx
@@ -114,11 +114,6 @@ const ServicesPage = () => {
         serviceData = property;
       }
 
-      // Para depuración - verificar si tenemos unitNumber
-      if (selectedService === 'apartments') {
-        console.log("Saving apartment with unitNumber:", serviceData.unitNumber);
-      }
-      
       Object.entries(serviceData).forEach(([key, value]) => {
         if (key !== 'images') {
           // Convertir valores undefined a string vacío

--- a/src/components/form/BookingForm.jsx
+++ b/src/components/form/BookingForm.jsx
@@ -99,7 +99,6 @@ function BookingForm({ service }) {
 
       setTimeout(() => {
         if (document.hidden) {
-          console.log(userData);
         } else {
           window.location.href = whatsappUrl
         }

--- a/src/components/form/ContactForm.jsx
+++ b/src/components/form/ContactForm.jsx
@@ -79,7 +79,7 @@ export default function ContactForm() {
         {
           from_name: `${formData.firstName} ${formData.lastName}`,
           from_email: formData.email,
-          phone: `${formData.phonePrefix} ${formData.phoneNumber}`,
+          phone: `${formData.phonePrefix} ${formData.phone}`,
           message: formData.message,
         },
         publicKey
@@ -187,10 +187,10 @@ export default function ContactForm() {
                 <Grid item xs={8}>
                   <TextField
                     fullWidth
-                    name="phoneNumber"
+                    name="phone"
                     type="tel"
                     label={t('contactUs.phone')}
-                    value={formData.phoneNumber}
+                    value={formData.phone}
                     onChange={handleChange}
                     variant="outlined"
                   />

--- a/src/components/images/ImageCarousel.jsx
+++ b/src/components/images/ImageCarousel.jsx
@@ -5,7 +5,6 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ImagePlaceholder from '../common/ImagePlaceholder';
 import LazyImage from '../common/LazyImage';
-import "slick-carousel/slick/slick.css"; 
 import useImageWithPlaceholder from '../../hooks/useImageWithPlaceholder';
 import useImagePreloader from '../../hooks/useImagePreloader';
 

--- a/src/hooks/useLazyImage.js
+++ b/src/hooks/useLazyImage.js
@@ -1,11 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 
-/**
- * Hook personalizado para implementar lazy loading de imágenes con Intersection Observer
- * @param {string} src - URL de la imagen
- * @param {Object} options - Opciones para el Intersection Observer
- * @returns {Object} - Estado y referencia para el lazy loading
- */
 const useLazyImage = (src, options = {}) => {
     const [imageSrc, setImageSrc] = useState(null);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -13,12 +7,13 @@ const useLazyImage = (src, options = {}) => {
     const [hasError, setHasError] = useState(false);
     const imgRef = useRef();
 
+    const { root = null, rootMargin = '50px', threshold = 0.1 } = options;
+
     const observerOptions = useMemo(() => ({
-        root: null,
-        rootMargin: '50px', // Cargar imagen cuando esté a 50px de ser visible
-        threshold: 0.1,
-        ...options
-    }), [options]);
+        root,
+        rootMargin,
+        threshold,
+    }), [root, rootMargin, threshold]);
 
     useEffect(() => {
         const observer = new IntersectionObserver(

--- a/src/hooks/useMonthlySummary.js
+++ b/src/hooks/useMonthlySummary.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
     generateSummary,
-    fetchSummaryDetails,
     downloadSummaryPDF,
     sendSummaryEmail,
     clearError,
@@ -17,26 +16,10 @@ export const useMonthlySummary = () => {
 
     const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
     const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
-    const [isInitialLoad, setIsInitialLoad] = useState(true);
 
-    // Efecto para cargar los datos iniciales
     useEffect(() => {
-        if (selectedMonth && selectedYear) {
-            if (isInitialLoad) {
-                dispatch(generateSummary({ month: selectedMonth, year: selectedYear }));
-                setIsInitialLoad(false);
-            } else {
-                dispatch(fetchSummaryDetails({ year: selectedYear, month: selectedMonth }));
-            }
-        }
-    }, [dispatch, selectedMonth, selectedYear, isInitialLoad]);
-
-    // Efecto para recargar cuando cambian mes o año
-    useEffect(() => {
-        if (!isInitialLoad) {
-            dispatch(generateSummary({ month: selectedMonth, year: selectedYear }));
-        }
-    }, [dispatch, isInitialLoad, selectedMonth, selectedYear]);
+        dispatch(generateSummary({ month: selectedMonth, year: selectedYear }));
+    }, [dispatch, selectedMonth, selectedYear]);
 
     const handleMonthChange = (newMonth) => {
         setSelectedMonth(newMonth);

--- a/src/hooks/useReservationForm.js
+++ b/src/hooks/useReservationForm.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchAdminApartments, selectAllApartments } from '../redux/adminApartmentSlice';
 import { fetchUsers, selectAllUsers, selectUserStatus } from '../redux/userSlice';
@@ -166,7 +166,7 @@ export const useReservationForm = (initialData) => {
         formData.amountPaid
     ]);
 
-    const handleChange = (event) => {
+    const handleChange = useCallback((event) => {
         const { name, value } = event.target;
 
         if (name === 'apartmentId') {
@@ -193,35 +193,23 @@ export const useReservationForm = (initialData) => {
                 }));
             }
         } else {
-            setFormData(prev => ({
-                ...prev,
-                [name]: value
-            }));
+            setFormData(prev => ({ ...prev, [name]: value }));
         }
-    };
+    }, [apartments]);
 
-    const handleDateChange = (name) => (date) => {
+    const handleDateChange = useCallback((name) => (date) => {
         if (date) {
-            // Convertir la fecha seleccionada al formato MM-DD-YYYY HH:mm
             const formattedDate = formatDateToString(date);
-            setFormData(prev => ({
-                ...prev,
-                [name]: formattedDate
-            }));
+            setFormData(prev => ({ ...prev, [name]: formattedDate }));
         } else {
-            setFormData(prev => ({
-                ...prev,
-                [name]: null
-            }));
+            setFormData(prev => ({ ...prev, [name]: null }));
         }
-    };
+    }, []);
 
-    const handleClientSelect = (client) => {
+    const handleClientSelect = useCallback((client) => {
         setSelectedClient(client);
         if (client) {
-            // Manejar diferentes formatos de nombres (firstName/lastName o name/lastname)
             const fullName = `${client.firstName || client.name || ''} ${client.lastName || client.lastname || ''}`.trim();
-
             setFormData(prev => ({
                 ...prev,
                 clientId: client.id.toString(),
@@ -246,15 +234,11 @@ export const useReservationForm = (initialData) => {
                 clientNotes: ''
             }));
         }
-    };
+    }, []);
 
-    const handleNewClientCreated = (newClient) => {
-        // Seleccionar el nuevo cliente como cliente activo
+    const handleNewClientCreated = useCallback((newClient) => {
         setSelectedClient(newClient);
-
-        // Actualizar el formulario con los datos del nuevo cliente
         const fullName = `${newClient.name || newClient.firstName || ''} ${newClient.lastname || newClient.lastName || ''}`.trim();
-
         setFormData(prev => ({
             ...prev,
             clientId: newClient.id ? newClient.id.toString() : '',
@@ -266,19 +250,19 @@ export const useReservationForm = (initialData) => {
             clientCountry: newClient.country || '',
             clientNotes: newClient.notes || ''
         }));
-    };
+    }, []);
 
-    // Función para manejar cambios en el pago inicial
-    const handleInitialPaymentChange = (paymentData) => {
+    const handleInitialPaymentChange = useCallback((paymentData) => {
         setInitialPaymentData(paymentData);
-        // El efecto de precios recalcula amountDue y paymentStatus cuando amountPaid cambia
         setFormData(prev => ({
             ...prev,
             amountPaid: paymentData.amount && paymentData.amount > 0
                 ? parseFloat(paymentData.amount)
                 : 0
         }));
-    }; const resetForm = () => {
+    }, []);
+
+    const resetForm = useCallback(() => {
         setFormData({
             apartmentId: '',
             name: '',
@@ -309,12 +293,8 @@ export const useReservationForm = (initialData) => {
         });
         setSelectedApartment(null);
         setSelectedClient(null);
-        setInitialPaymentData({
-            amount: '',
-            paymentMethod: 'cash',
-            notes: ''
-        });
-    };
+        setInitialPaymentData({ amount: '', paymentMethod: 'cash', notes: '' });
+    }, []);
 
     return {
         formData,

--- a/src/hooks/useReservationForm.js
+++ b/src/hooks/useReservationForm.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchAdminApartments, selectAllApartments } from '../redux/adminApartmentSlice';
 import { fetchUsers, selectAllUsers, selectUserStatus } from '../redux/userSlice';
-import { formatDateToString, parseStringToDate, calculateNights } from '../utils/dateUtils';
+import { formatDateToString, calculateNights } from '../utils/dateUtils';
 
 export const useReservationForm = (initialData) => {
     const dispatch = useDispatch();
@@ -115,57 +115,50 @@ export const useReservationForm = (initialData) => {
         }
     }, [initialData, apartments, clients]);
 
-    // Calcular noches cuando cambian las fechas
+    // Calcular noches y precios derivados en un solo efecto para evitar renders en cascada
     useEffect(() => {
-        if (formData.checkInDate && formData.checkOutDate) {
-            // Usar la función de utilidad para calcular noches entre fechas
-            const nights = calculateNights(formData.checkInDate, formData.checkOutDate);
+        if (!formData.checkInDate || !formData.checkOutDate) return;
 
-            if (formData.nights !== nights) { // Evitar actualizaciones innecesarias
-                setFormData(prev => ({
-                    ...prev,
-                    nights
-                }));
-            }
-        }
-    }, [formData.checkInDate, formData.checkOutDate, formData.nights]);
+        const nights = calculateNights(formData.checkInDate, formData.checkOutDate);
+        const price = Number(formData.price);
+        const cleaningFee = Number(formData.cleaningFee) || 0;
+        const parkingFee = Number(formData.parkingFee) || 0;
+        const otherExpenses = Number(formData.otherExpenses) || 0;
+        const taxes = Number(formData.taxes) || 0;
+        const amountPaid = Number(formData.amountPaid) || 0;
 
-    // Calcular precios
-    useEffect(() => {
-        if (formData.nights > 0 && formData.price > 0) {
-            const price = Number(formData.price);
-            const nights = Number(formData.nights);
-            const cleaningFee = Number(formData.cleaningFee) || 0;
-            const parkingFee = Number(formData.parkingFee) || 0;
-            const otherExpenses = Number(formData.otherExpenses) || 0;
-            const taxes = Number(formData.taxes) || 0; // Solo usar taxes si fueron ingresados manualmente
-            const amountPaid = Number(formData.amountPaid) || 0;
+        // cancellationFee es un ítem aparte y NO suma al subtotal
+        const subtotal = price * nights + cleaningFee + parkingFee + otherExpenses;
+        const total = subtotal + taxes;
+        const due = total - amountPaid;
 
-            const accommodationTotal = price * nights;
-            // cancellationFee es un ítem aparte y NO suma al subtotal
-            const subtotal = accommodationTotal + cleaningFee + parkingFee + otherExpenses;
+        let paymentStatus = 'pending';
+        if (due <= 0) paymentStatus = 'complete';
+        else if (amountPaid > 0) paymentStatus = 'partial';
 
-            // Solo sumar taxes si el usuario los ingresó manualmente
-            const total = subtotal + taxes;
-            const due = total - amountPaid;
+        const newTotalAmount = parseFloat(total.toFixed(2));
+        const newAmountDue = parseFloat(due.toFixed(2));
 
-            let paymentStatus = 'pending';
-            if (due <= 0) {
-                paymentStatus = 'complete';
-            } else if (amountPaid > 0) {
-                paymentStatus = 'partial';
-            }
+        setFormData(prev => {
+            if (
+                prev.nights === nights &&
+                prev.totalAmount === newTotalAmount &&
+                prev.amountDue === newAmountDue &&
+                prev.paymentStatus === paymentStatus
+            ) return prev;
 
-            setFormData(prev => ({
+            return {
                 ...prev,
-                totalAmount: parseFloat(total.toFixed(2)),
-                amountDue: parseFloat(due.toFixed(2)),
+                nights,
+                totalAmount: newTotalAmount,
+                amountDue: newAmountDue,
                 paymentStatus
-            }));
-        }
+            };
+        });
     }, [
+        formData.checkInDate,
+        formData.checkOutDate,
         formData.price,
-        formData.nights,
         formData.cleaningFee,
         formData.parkingFee,
         formData.otherExpenses,
@@ -278,25 +271,13 @@ export const useReservationForm = (initialData) => {
     // Función para manejar cambios en el pago inicial
     const handleInitialPaymentChange = (paymentData) => {
         setInitialPaymentData(paymentData);
-
-        // Actualizar los valores calculados en el formData si hay un pago inicial
-        if (paymentData.amount && paymentData.amount > 0) {
-            const amount = parseFloat(paymentData.amount);
-            const totalAmount = parseFloat(formData.totalAmount) || 0;
-
-            setFormData(prev => ({
-                ...prev,
-                amountPaid: amount,
-                amountDue: Math.max(0, totalAmount - amount)
-            }));
-        } else {
-            // Si no hay pago inicial, resetear valores
-            setFormData(prev => ({
-                ...prev,
-                amountPaid: 0,
-                amountDue: parseFloat(prev.totalAmount) || 0
-            }));
-        }
+        // El efecto de precios recalcula amountDue y paymentStatus cuando amountPaid cambia
+        setFormData(prev => ({
+            ...prev,
+            amountPaid: paymentData.amount && paymentData.amount > 0
+                ? parseFloat(paymentData.amount)
+                : 0
+        }));
     }; const resetForm = () => {
         setFormData({
             apartmentId: '',

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { Container, Box, useTheme, useMediaQuery } from '@mui/material';
 import { motion, AnimatePresence } from 'framer-motion';
 
 import WhatsAppIcon from '../components/WhatsAppIcon';
 
-import Services from './Services';
-import About from './About';
-import GoogleReviews from '../components/admin/reviews/GoogleReviewsManager';
-import AboutFounder from '../components/about/AboutFounder';
-import ContactForm from '../components/form/ContactForm';
+const Services = lazy(() => import('./Services'));
+const About = lazy(() => import('./About'));
+const GoogleReviews = lazy(() => import('../components/admin/reviews/GoogleReviewsManager'));
+const AboutFounder = lazy(() => import('../components/about/AboutFounder'));
+const ContactForm = lazy(() => import('../components/form/ContactForm'));
 
 const Home = () => {
   const theme = useTheme();
@@ -129,48 +129,58 @@ const Home = () => {
       </Box>
       </motion.div>
 
-      <Box sx={{ 
-        py: { xs: 4, sm: 6, md: 8 }, 
+      <Box sx={{
+        py: { xs: 4, sm: 6, md: 8 },
         backgroundColor: '#1e1e1e',
       }}>
         <Container maxWidth="xl" sx={{ mt: -10 }}>
-          <Services />
+          <Suspense fallback={<Box sx={{ minHeight: 200, backgroundColor: '#1e1e1e' }} />}>
+            <Services />
+          </Suspense>
         </Container>
       </Box>
 
-      <Box sx={{ 
-        py: { xs: 4, sm: 6, md: 8 }, 
+      <Box sx={{
+        py: { xs: 4, sm: 6, md: 8 },
         backgroundColor: '#121212',
       }}>
         <Container maxWidth="lg" sx={{ mt: -10 }}>
-          <About />
+          <Suspense fallback={<Box sx={{ minHeight: 200, backgroundColor: '#121212' }} />}>
+            <About />
+          </Suspense>
         </Container>
       </Box>
 
-      <Box sx={{ 
-        py: { xs: 4, sm: 6, md: 8 }, 
+      <Box sx={{
+        py: { xs: 4, sm: 6, md: 8 },
         backgroundColor: '#1e1e1e',
       }}>
         <Container sx={{ mt: -10 }}>
-          <GoogleReviews />
+          <Suspense fallback={<Box sx={{ minHeight: 200, backgroundColor: '#1e1e1e' }} />}>
+            <GoogleReviews />
+          </Suspense>
         </Container>
       </Box>
 
-      <Box sx={{ 
-        py: { xs: 4, sm: 6, md: 8 }, 
+      <Box sx={{
+        py: { xs: 4, sm: 6, md: 8 },
         backgroundColor: '#121212',
       }}>
         <Container maxWidth="xl">
-          <AboutFounder />
+          <Suspense fallback={<Box sx={{ minHeight: 200, backgroundColor: '#121212' }} />}>
+            <AboutFounder />
+          </Suspense>
         </Container>
       </Box>
 
-      <Box sx={{ 
-        py: { xs: 4, sm: 6, md: 8 }, 
+      <Box sx={{
+        py: { xs: 4, sm: 6, md: 8 },
         backgroundColor: '#1e1e1e',
       }}>
         <Container sx={{ mt: -10 }}>
-          <ContactForm />
+          <Suspense fallback={<Box sx={{ minHeight: 200, backgroundColor: '#1e1e1e' }} />}>
+            <ContactForm />
+          </Suspense>
         </Container>
       </Box>
 

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -4,9 +4,6 @@ import { Container, Typography, Grid2, Card, CardContent, Button, Box, useTheme,
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 
-import "slick-carousel/slick/slick.css"; 
-import "slick-carousel/slick/slick-theme.css";
-
 import ImageCarousel from '../components/images/ImageCarousel';
 import BookingForm from '../components/form/BookingForm';
 import WhatsAppButton from '../components/WhatsAppIcon';

--- a/src/pages/ServiceList.jsx
+++ b/src/pages/ServiceList.jsx
@@ -18,9 +18,6 @@ import {
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 
-import "slick-carousel/slick/slick.css";
-import "slick-carousel/slick/slick-theme.css";
-
 import ImageCarousel from "../components/images/ImageCarousel";
 import WhatsAppIcon from "../components/WhatsAppIcon";
 import PublicServiceFilters from "../components/filters/PublicServiceFilters";

--- a/src/redux/adminApartmentSlice.js
+++ b/src/redux/adminApartmentSlice.js
@@ -1,31 +1,16 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { normalizeApartmentFromApi } from '../utils/normalizers';
-import axios from 'axios';
-import config from '../config';
+import api from '../utils/api';
 
-const getToken = () => localStorage.getItem('adminToken');
-
-const api = axios.create({
-    baseURL: config.API_URL,
-});
-
-api.interceptors.request.use(
-    (config) => {
-        const token = getToken();
-        if (token) {
-            config.headers['Authorization'] = `Bearer ${token}`;
-        }
-        return config;
-    },
-    (error) => Promise.reject(error)
-);
-
-// Thunks para operaciones CRUD
 export const fetchAdminApartments = createAsyncThunk(
     'adminApartments/fetchAll',
-    async () => {
-        const response = await api.get('/apartments');
-        return response.data;
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await api.get('/apartments');
+            return response.data;
+        } catch (error) {
+            return rejectWithValue(error.response?.data?.message || 'Error fetching apartments');
+        }
     }
 );
 
@@ -43,25 +28,37 @@ export const fetchAdminApartmentById = createAsyncThunk(
 
 export const createAdminApartment = createAsyncThunk(
     'adminApartments/create',
-    async (apartmentData) => {
-        const response = await api.post('/apartments', apartmentData);
-        return response.data;
+    async (apartmentData, { rejectWithValue }) => {
+        try {
+            const response = await api.post('/apartments', apartmentData);
+            return response.data;
+        } catch (error) {
+            return rejectWithValue(error.response?.data?.message || 'Error creating apartment');
+        }
     }
 );
 
 export const updateAdminApartment = createAsyncThunk(
     'adminApartments/update',
-    async ({ id, data }) => {
-        const response = await api.put(`/apartments/${id}`, data);
-        return response.data;
+    async ({ id, data }, { rejectWithValue }) => {
+        try {
+            const response = await api.put(`/apartments/${id}`, data);
+            return response.data;
+        } catch (error) {
+            return rejectWithValue(error.response?.data?.message || 'Error updating apartment');
+        }
     }
 );
 
 export const deleteAdminApartment = createAsyncThunk(
     'adminApartments/delete',
-    async (id) => {
-        await api.delete(`/apartments/${id}`);
-        return id;
+    async (id, { rejectWithValue }) => {
+        try {
+            await api.delete(`/apartments/${id}`);
+            return id;
+        } catch (error) {
+            return rejectWithValue(error.response?.data?.message || 'Error deleting apartment');
+        }
     }
 );
 
@@ -103,7 +100,7 @@ const adminApartmentSlice = createSlice({
             })
             .addCase(fetchAdminApartments.rejected, (state, action) => {
                 state.status = 'failed';
-                state.error = action.error.message;
+                state.error = action.payload ?? action.error.message;
                 state.loading = false;
             })
             // Fetch By Id
@@ -118,7 +115,7 @@ const adminApartmentSlice = createSlice({
             })
             .addCase(fetchAdminApartmentById.rejected, (state, action) => {
                 state.status = 'failed';
-                state.error = action.error.message;
+                state.error = action.payload ?? action.error.message;
                 state.loading = false;
             })
             // Create
@@ -127,7 +124,7 @@ const adminApartmentSlice = createSlice({
                 state.error = null;
             })
             .addCase(createAdminApartment.rejected, (state, action) => {
-                state.error = action.error.message;
+                state.error = action.payload ?? action.error.message;
             })
             // Update
             .addCase(updateAdminApartment.fulfilled, (state, action) => {
@@ -142,7 +139,7 @@ const adminApartmentSlice = createSlice({
                 state.error = null;
             })
             .addCase(updateAdminApartment.rejected, (state, action) => {
-                state.error = action.error.message;
+                state.error = action.payload ?? action.error.message;
             })
             // Delete
             .addCase(deleteAdminApartment.fulfilled, (state, action) => {
@@ -153,7 +150,7 @@ const adminApartmentSlice = createSlice({
                 state.error = null;
             })
             .addCase(deleteAdminApartment.rejected, (state, action) => {
-                state.error = action.error.message;
+                state.error = action.payload ?? action.error.message;
             });
     },
 });

--- a/src/redux/reservationSlice.js
+++ b/src/redux/reservationSlice.js
@@ -311,9 +311,9 @@ const reservationSlice = createSlice({
             })
             .addCase(generateReservationPdf.fulfilled, (state, action) => {
                 state.loading = false;
-                const { id, pdfUrl, email } = action.payload;
+                const { id, downloadUrl, email } = action.payload;
                 if (state.selectedReservation?.id === id) {
-                    state.selectedReservation.pdfUrl = pdfUrl;
+                    state.selectedReservation.pdfUrl = downloadUrl;
                 }
             })
             .addCase(generateReservationPdf.rejected, (state, action) => {

--- a/src/redux/supplierSlice.js
+++ b/src/redux/supplierSlice.js
@@ -52,6 +52,10 @@ const supplierSlice = createSlice({
     reducers: {},
     extraReducers: (builder) => {
         builder
+            .addCase(fetchAllSuppliers.pending, (state) => {
+                state.status = 'loading';
+                state.error = null;
+            })
             .addCase(fetchAllSuppliers.fulfilled, (state, action) => {
                 state.status = 'succeeded';
                 const raw = action.payload;
@@ -66,15 +70,37 @@ const supplierSlice = createSlice({
                     state.pagination = null;
                 }
             })
+            .addCase(fetchAllSuppliers.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload ?? action.error.message;
+            })
+            .addCase(createSupplier.pending, (state) => {
+                state.error = null;
+            })
             .addCase(createSupplier.fulfilled, (state, action) => {
                 state.suppliers.push(action.payload);
+            })
+            .addCase(createSupplier.rejected, (state, action) => {
+                state.error = action.payload ?? action.error.message;
+            })
+            .addCase(updateSupplier.pending, (state) => {
+                state.error = null;
             })
             .addCase(updateSupplier.fulfilled, (state, action) => {
                 const i = state.suppliers.findIndex(s => s.id === action.payload.id);
                 if (i !== -1) state.suppliers[i] = action.payload;
             })
+            .addCase(updateSupplier.rejected, (state, action) => {
+                state.error = action.payload ?? action.error.message;
+            })
+            .addCase(deleteSupplier.pending, (state) => {
+                state.error = null;
+            })
             .addCase(deleteSupplier.fulfilled, (state, action) => {
                 state.suppliers = state.suppliers.filter(s => s.id !== action.payload);
+            })
+            .addCase(deleteSupplier.rejected, (state, action) => {
+                state.error = action.payload ?? action.error.message;
             });
     },
 });

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -3,9 +3,8 @@ import config from '../config'
 
 const api = axios.create({
     baseURL: config.API_URL,
-    // Deja que Axios determine automáticamente el Content-Type según el payload.
-    // Esto es clave para que FormData se envíe como multipart/form-data con boundary.
-    withCredentials: true
+    // No setear Content-Type: Axios lo determina automáticamente.
+    // Clave para que FormData se envíe como multipart/form-data con boundary correcto.
 })
 
 api.interceptors.request.use(

--- a/src/utils/pdfUtils.js
+++ b/src/utils/pdfUtils.js
@@ -1,12 +1,6 @@
 import api from './api'
 
 export const downloadReservationPdf = async (id) => {
-    const token = localStorage.getItem('adminToken');
-
-    if (!token) {
-        throw new Error('No authentication token available. Please log in again.');
-    }
-
     const reservationResponse = await api.get(`/reservations/${id}`);
     const reservationData = reservationResponse.data;
 
@@ -25,7 +19,6 @@ export const downloadReservationPdf = async (id) => {
     const response = await api.get(`/reservations/${id}/pdf/download?${queryParams.toString()}`, {
         responseType: 'blob',
         headers: {
-            'Authorization': `Bearer ${token}`,
             'Accept': 'application/pdf'
         }
     });


### PR DESCRIPTION
## Summary

Resultado de una auditoría completa del frontend. 18 fixes aplicados en dos sesiones, organizados por prioridad.

### Features incluidas (commits previos)
- Supplier payout section, receipt lightbox y fixes de pagos
- Paginación server-side en todas las vistas de lista

### Performance
- **Home**: secciones lazy-loaded con `React.lazy` — chunk de 524KB → 4.41KB standalone
- **AdminDashboard**: charts (`BookingTrendsChart`, `SalesVolumeChart`, `MonthlySummary`) lazy por tab — Recharts (~414KB) fuera del bundle inicial
- **ReservationForm**: `React.memo` + `useCallback` en las 8 secciones — corta re-renders en cascada
- **useReservationForm**: efectos de noches y precios fusionados — elimina 2 renders extra por cambio de campo
- **useLazyImage**: `IntersectionObserver` dejó de recrearse en cada render (deps eran object literal inestable)
- **ReservationList**: tabla compactada (Period column + sin Creation Date), `sortReservations` fuera del componente, sort memoizado

### Fixes de API / Redux
- **429 Too Many Requests**: `ReservationList` llamaba `getAllApartments()` en cada mount — reemplazado por Redux con guard `status === 'idle'`
- **AdminDashboard**: eliminados 5 fetches redundantes en cada mount + doble normalización de datos
- **useMonthlySummary**: eliminado double fetch al montar
- **supplierSlice**: agregados casos `pending`/`rejected` a los 4 thunks
- **adminApartmentSlice**: eliminada instancia axios duplicada, unificada con `api.js`

### Fixes de seguridad / correctness
- **api.js**: eliminado `withCredentials: true` (contradictorio con JWT via `Authorization` header)
- **pdfUtils.js**: eliminado header `Authorization` manual (redundante con interceptor de `api.js`)
- **reservationSlice**: `generateReservationPdf` destructuraba `pdfUrl` pero el thunk retorna `downloadUrl` — siempre era `undefined`
- **ContactForm**: campo `phone` enviaba siempre vacío (`name="phoneNumber"` vs state `phone`)

### DX / cleanup
- **slick-carousel CSS**: eliminados imports duplicados en 3 archivos (`main.jsx` ya los importa globalmente)
- **AdminLogin**: botón deshabilitado si campos vacíos, spinner durante login
- **console.log**: eliminados 2 restantes en producción

## Test plan

- [x] Navegar entre reservas rápido — no debe aparecer error 429
- [x] Abrir formulario de reserva y editar un campo — solo la sección correspondiente debe re-renderizar
- [x] Dashboard: verificar que los tabs 1 y 2 cargan sus charts al hacer click (lazy)
- [x] Descargar PDF de una reserva — debe funcionar sin errores
- [x] Formulario de contacto — verificar que el teléfono se envía correctamente
- [x] AdminLogin — botón deshabilitado con campos vacíos, spinner al hacer submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)