### PR TITLE
feat: investments — public listing, detail page, admin CRUD

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,9 @@ const ServicesPage = lazy(() => import('./components/admin/services/ServicesPage
 const CreateUser = lazy(() => import('./components/admin/users/CreateUser'));
 const EditUser = lazy(() => import('./components/admin/users/EditUser'));
 const SupplierList = lazy(() => import('./components/admin/suppliers/SupplierList'));
+const InvestmentsPage = lazy(() => import('./pages/InvestmentsPage'));
+const InvestmentDetailPage = lazy(() => import('./pages/InvestmentDetailPage'));
+const InvestmentList = lazy(() => import('./components/admin/investments/InvestmentList'));
 
 const theme = createTheme({
   palette: {
@@ -107,7 +110,10 @@ function AppContent() {
               <Route path="reviews" element={<AdminReviews />} />
               <Route path="apartments" element={<ApartmentList />} />
               <Route path="suppliers" element={<SupplierList />} />
+              <Route path="investments" element={<InvestmentList />} />
             </Route>
+            <Route path="/investments" element={<InvestmentsPage />} />
+            <Route path="/investments/:id" element={<InvestmentDetailPage />} />
             <Route path="/reservations" element={<ReservationsPage />} />
             <Route path="/reservations/:id" element={<ReservationDetailsPage />} />
           </Routes>

--- a/src/components/admin/investments/InvestmentList.jsx
+++ b/src/components/admin/investments/InvestmentList.jsx
@@ -1,0 +1,470 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+    Box, Button, Card, CardActions, CardContent, CardMedia, Chip,
+    CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
+    Divider, Grid, IconButton, Paper, Skeleton,
+    Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+    TextField, Tooltip, Typography,
+} from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import BathtubOutlinedIcon from '@mui/icons-material/BathtubOutlined';
+import BedOutlinedIcon from '@mui/icons-material/BedOutlined';
+import ImageIcon from '@mui/icons-material/Image';
+import {
+    fetchAllInvestments, createInvestment, updateInvestment, deleteInvestment,
+    selectAllInvestments, selectInvestmentsStatus,
+} from '../../../redux/investmentSlice';
+import DeleteDialog from '../dialogs/DeleteDialog';
+import useDeviceDetection from '../../../hooks/useDeviceDetection';
+
+const fieldSx = {
+    '& .MuiOutlinedInput-root': {
+        bgcolor: '#252525',
+        '& fieldset': { borderColor: '#3a3a3a' },
+        '&:hover fieldset': { borderColor: '#555' },
+        '&.Mui-focused fieldset': { borderColor: '#6c5dd3' },
+    },
+    '& .MuiInputLabel-root': { color: '#777' },
+    '& .MuiInputBase-input': { color: '#fff' },
+};
+
+const emptyForm = {
+    name: '',
+    address: '',
+    unit_number: '',
+    description: '',
+    bathrooms: '',
+    rooms: '',
+    price: '',
+};
+
+const formatPrice = (price) =>
+    price === null || price === undefined
+        ? 'Price on request'
+        : `$${Number(price).toLocaleString('en-US')}`;
+
+const InvestmentForm = ({ form, onChange, imageFiles, onImageChange, isEdit }) => (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+        <TextField
+            label="Name *" name="name" value={form.name}
+            onChange={onChange} fullWidth sx={fieldSx}
+        />
+        <TextField
+            label="Address *" name="address" value={form.address}
+            onChange={onChange} fullWidth sx={fieldSx}
+        />
+        <TextField
+            label="Unit number" name="unit_number" value={form.unit_number}
+            onChange={onChange} fullWidth sx={fieldSx}
+        />
+        <Box sx={{ display: 'flex', gap: 2 }}>
+            <TextField
+                label="Rooms *" name="rooms" value={form.rooms} type="number"
+                onChange={onChange} fullWidth sx={fieldSx}
+                inputProps={{ min: 1 }}
+            />
+            <TextField
+                label="Bathrooms *" name="bathrooms" value={form.bathrooms} type="number"
+                onChange={onChange} fullWidth sx={fieldSx}
+                inputProps={{ min: 0 }}
+            />
+        </Box>
+        <TextField
+            label="Price (leave empty = price on request)" name="price" value={form.price} type="number"
+            onChange={onChange} fullWidth sx={fieldSx}
+            inputProps={{ min: 0 }}
+        />
+        <TextField
+            label="Description" name="description" value={form.description}
+            onChange={onChange} fullWidth multiline rows={3}
+            sx={fieldSx}
+        />
+        <Box>
+            <Button
+                component="label"
+                variant="outlined"
+                startIcon={<ImageIcon />}
+                sx={{ color: '#aaa', borderColor: '#3a3a3a', '&:hover': { borderColor: '#6c5dd3' } }}
+            >
+                {imageFiles.length > 0 ? `${imageFiles.length} image(s) selected` : 'Select images'}
+                <input
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    hidden
+                    onChange={onImageChange}
+                />
+            </Button>
+            {isEdit && imageFiles.length === 0 && (
+                <Typography variant="caption" sx={{ color: '#777', display: 'block', mt: 0.5 }}>
+                    Leave empty to keep existing images. Uploading new images replaces all existing ones.
+                </Typography>
+            )}
+            {imageFiles.length > 0 && (
+                <Typography variant="caption" sx={{ color: '#aaa', display: 'block', mt: 0.5 }}>
+                    {imageFiles.map(f => f.name).join(', ')}
+                </Typography>
+            )}
+        </Box>
+    </Box>
+);
+
+const InvestmentList = () => {
+    const dispatch = useDispatch();
+    const { isMobile, isTablet } = useDeviceDetection();
+    const investments = useSelector(selectAllInvestments);
+    const status = useSelector(selectInvestmentsStatus);
+
+    const [createOpen, setCreateOpen] = useState(false);
+    const [editOpen, setEditOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [selected, setSelected] = useState(null);
+    const [form, setForm] = useState(emptyForm);
+    const [imageFiles, setImageFiles] = useState([]);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        if (status === 'idle') dispatch(fetchAllInvestments());
+    }, [dispatch, status]);
+
+    const handleFormChange = (e) => {
+        const { name, value } = e.target;
+        setForm(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleImageChange = (e) => {
+        const files = Array.from(e.target.files).slice(0, 30);
+        setImageFiles(files);
+    };
+
+    const buildFormData = () => {
+        const fd = new FormData();
+        fd.append('name', form.name.trim());
+        fd.append('address', form.address.trim());
+        if (form.unit_number.trim()) fd.append('unit_number', form.unit_number.trim());
+        if (form.description.trim()) fd.append('description', form.description.trim());
+        fd.append('rooms', form.rooms);
+        fd.append('bathrooms', form.bathrooms);
+        if (form.price !== '') fd.append('price', form.price);
+        imageFiles.forEach(file => fd.append('images', file));
+        return fd;
+    };
+
+    const isFormValid = () =>
+        form.name.trim() && form.address.trim() &&
+        form.rooms !== '' && Number(form.rooms) > 0 &&
+        form.bathrooms !== '' && Number(form.bathrooms) >= 0;
+
+    const openCreate = () => {
+        setForm(emptyForm);
+        setImageFiles([]);
+        setCreateOpen(true);
+    };
+
+    const openEdit = (inv) => {
+        setSelected(inv);
+        setForm({
+            name: inv.name || '',
+            address: inv.address || '',
+            unit_number: inv.unit_number || '',
+            description: inv.description || '',
+            bathrooms: inv.bathrooms ?? '',
+            rooms: inv.rooms ?? '',
+            price: inv.price ?? '',
+        });
+        setImageFiles([]);
+        setEditOpen(true);
+    };
+
+    const openDelete = (inv) => {
+        setSelected(inv);
+        setDeleteOpen(true);
+    };
+
+    const handleCreate = async () => {
+        if (!isFormValid()) return;
+        setSaving(true);
+        try {
+            await dispatch(createInvestment(buildFormData())).unwrap();
+            setCreateOpen(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleEdit = async () => {
+        if (!isFormValid() || !selected) return;
+        setSaving(true);
+        try {
+            await dispatch(updateInvestment({ id: selected.id, formData: buildFormData() })).unwrap();
+            setEditOpen(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!selected) return;
+        try {
+            await dispatch(deleteInvestment(selected.id)).unwrap();
+            setDeleteOpen(false);
+            setSelected(null);
+        } catch {
+            // handled by slice
+        }
+    };
+
+    const dialogProps = {
+        maxWidth: 'sm',
+        fullWidth: true,
+        PaperProps: { sx: { bgcolor: '#1a1a1a', color: '#fff' } },
+    };
+
+    if (status === 'loading') {
+        return (
+            <Box sx={{ p: 3 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                    <Skeleton variant="text" width={180} height={40} />
+                    <Skeleton variant="rectangular" width={160} height={36} />
+                </Box>
+                <TableContainer component={Paper} sx={{ bgcolor: '#1e1e1e' }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                {['Property', 'Address', 'Rooms / Baths', 'Price', 'Actions'].map(h => (
+                                    <TableCell key={h}>{h}</TableCell>
+                                ))}
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {[...Array(4)].map((_, i) => (
+                                <TableRow key={i}>
+                                    {[160, 220, 100, 120, 80].map((w, j) => (
+                                        <TableCell key={j}><Skeleton variant="text" width={w} /></TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ p: 3 }}>
+            {/* Header */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <TrendingUpIcon sx={{ color: '#6c5dd3' }} />
+                    <Typography variant="h4">Investments</Typography>
+                </Box>
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={openCreate}
+                    sx={{ bgcolor: '#6c5dd3', '&:hover': { bgcolor: '#7c5cbf' } }}
+                >
+                    New Investment
+                </Button>
+            </Box>
+
+            {investments.length === 0 ? (
+                <Box sx={{ textAlign: 'center', py: 8, color: '#666' }}>
+                    <TrendingUpIcon sx={{ fontSize: 48, mb: 1, color: '#333' }} />
+                    <Typography variant="body1">No investments yet.</Typography>
+                    <Typography variant="body2" sx={{ mt: 0.5 }}>Click "+ New Investment" to add the first one.</Typography>
+                </Box>
+            ) : isMobile || isTablet ? (
+                <Grid container spacing={2}>
+                    {investments.map(inv => (
+                        <Grid item xs={12} sm={6} key={inv.id}>
+                            <Card sx={{ bgcolor: '#2a2a2a', border: '1px solid #333' }}>
+                                {inv.images?.[0] && (
+                                    <CardMedia
+                                        component="img"
+                                        height="160"
+                                        image={inv.images[0]}
+                                        alt={inv.name}
+                                        sx={{ objectFit: 'cover' }}
+                                    />
+                                )}
+                                <CardContent>
+                                    <Typography variant="h6" sx={{ color: '#fff' }}>
+                                        {inv.name}{inv.unit_number ? ` — Unit ${inv.unit_number}` : ''}
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ color: '#aaa', mb: 1 }}>{inv.address}</Typography>
+                                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                                        <Chip icon={<BedOutlinedIcon />} label={`${inv.rooms} rooms`} size="small" sx={{ bgcolor: '#333', color: '#ddd' }} />
+                                        <Chip icon={<BathtubOutlinedIcon />} label={`${inv.bathrooms} baths`} size="small" sx={{ bgcolor: '#333', color: '#ddd' }} />
+                                    </Box>
+                                    <Typography variant="body1" sx={{ color: '#6c5dd3', fontWeight: 600 }}>
+                                        {formatPrice(inv.price)}
+                                    </Typography>
+                                </CardContent>
+                                <Divider sx={{ borderColor: '#333' }} />
+                                <CardActions sx={{ justifyContent: 'flex-end', p: 1 }}>
+                                    <IconButton size="small" onClick={() => openEdit(inv)} sx={{ color: '#6c5dd3' }}>
+                                        <EditIcon />
+                                    </IconButton>
+                                    <IconButton size="small" onClick={() => openDelete(inv)} color="error">
+                                        <DeleteIcon />
+                                    </IconButton>
+                                </CardActions>
+                            </Card>
+                        </Grid>
+                    ))}
+                </Grid>
+            ) : (
+                <TableContainer component={Paper} sx={{ bgcolor: '#1e1e1e' }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow sx={{ '& th': { color: '#aaa', fontWeight: 600, borderColor: '#333' } }}>
+                                <TableCell>Property</TableCell>
+                                <TableCell>Address</TableCell>
+                                <TableCell>Rooms / Baths</TableCell>
+                                <TableCell>Price</TableCell>
+                                <TableCell>Actions</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {investments.map(inv => (
+                                <TableRow
+                                    key={inv.id}
+                                    sx={{ '&:hover': { bgcolor: '#2a2a2a' }, '& td': { borderColor: '#2a2a2a', color: '#ddd' } }}
+                                >
+                                    <TableCell>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                                            {inv.images?.[0] ? (
+                                                <Box
+                                                    component="img"
+                                                    src={inv.images[0]}
+                                                    alt={inv.name}
+                                                    sx={{ width: 48, height: 36, borderRadius: 1, objectFit: 'cover', flexShrink: 0 }}
+                                                />
+                                            ) : (
+                                                <Box sx={{
+                                                    width: 48, height: 36, borderRadius: 1, bgcolor: '#333',
+                                                    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                                                }}>
+                                                    <ImageIcon sx={{ fontSize: 16, color: '#555' }} />
+                                                </Box>
+                                            )}
+                                            <Box>
+                                                <Typography variant="body2" sx={{ color: '#fff', fontWeight: 500 }}>
+                                                    {inv.name}
+                                                </Typography>
+                                                {inv.unit_number && (
+                                                    <Typography variant="caption" sx={{ color: '#777' }}>
+                                                        Unit {inv.unit_number}
+                                                    </Typography>
+                                                )}
+                                            </Box>
+                                        </Box>
+                                    </TableCell>
+                                    <TableCell sx={{ maxWidth: 220 }}>
+                                        <Typography variant="body2" sx={{
+                                            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                                        }}>
+                                            {inv.address}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Box sx={{ display: 'flex', gap: 0.5 }}>
+                                            <Chip icon={<BedOutlinedIcon />} label={inv.rooms} size="small" sx={{ bgcolor: '#333', color: '#ddd' }} />
+                                            <Chip icon={<BathtubOutlinedIcon />} label={inv.bathrooms} size="small" sx={{ bgcolor: '#333', color: '#ddd' }} />
+                                        </Box>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Typography variant="body2" sx={{ color: '#6c5dd3', fontWeight: 600 }}>
+                                            {formatPrice(inv.price)}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Tooltip title="Edit">
+                                            <IconButton size="small" onClick={() => openEdit(inv)} sx={{ color: '#6c5dd3' }}>
+                                                <EditIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Delete">
+                                            <IconButton size="small" onClick={() => openDelete(inv)} color="error">
+                                                <DeleteIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            )}
+
+            {/* Create dialog */}
+            <Dialog open={createOpen} onClose={() => setCreateOpen(false)} {...dialogProps}>
+                <DialogTitle sx={{ borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <TrendingUpIcon sx={{ color: '#6c5dd3' }} />
+                    New Investment
+                </DialogTitle>
+                <DialogContent sx={{ pt: 2 }}>
+                    <InvestmentForm
+                        form={form} onChange={handleFormChange}
+                        imageFiles={imageFiles} onImageChange={handleImageChange}
+                        isEdit={false}
+                    />
+                </DialogContent>
+                <DialogActions sx={{ borderTop: '1px solid #333', px: 3, py: 2 }}>
+                    <Button onClick={() => setCreateOpen(false)} sx={{ color: '#aaa' }}>Cancel</Button>
+                    <Button
+                        onClick={handleCreate}
+                        disabled={saving || !isFormValid()}
+                        variant="contained"
+                        sx={{ bgcolor: '#6c5dd3', '&:hover': { bgcolor: '#7c5cbf' } }}
+                        startIcon={saving ? <CircularProgress size={14} color="inherit" /> : null}
+                    >
+                        {saving ? 'Saving…' : 'Create'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Edit dialog */}
+            <Dialog open={editOpen} onClose={() => setEditOpen(false)} {...dialogProps}>
+                <DialogTitle sx={{ borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <EditIcon sx={{ color: '#6c5dd3' }} />
+                    Edit Investment
+                </DialogTitle>
+                <DialogContent sx={{ pt: 2 }}>
+                    <InvestmentForm
+                        form={form} onChange={handleFormChange}
+                        imageFiles={imageFiles} onImageChange={handleImageChange}
+                        isEdit
+                    />
+                </DialogContent>
+                <DialogActions sx={{ borderTop: '1px solid #333', px: 3, py: 2 }}>
+                    <Button onClick={() => setEditOpen(false)} sx={{ color: '#aaa' }}>Cancel</Button>
+                    <Button
+                        onClick={handleEdit}
+                        disabled={saving || !isFormValid()}
+                        variant="contained"
+                        sx={{ bgcolor: '#6c5dd3', '&:hover': { bgcolor: '#7c5cbf' } }}
+                        startIcon={saving ? <CircularProgress size={14} color="inherit" /> : null}
+                    >
+                        {saving ? 'Saving…' : 'Save Changes'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Delete dialog */}
+            <DeleteDialog
+                open={deleteOpen}
+                onClose={() => { setDeleteOpen(false); setSelected(null); }}
+                onConfirm={handleDelete}
+            />
+        </Box>
+    );
+};
+
+export default InvestmentList;

--- a/src/components/admin/shared/DashboardHeader.jsx
+++ b/src/components/admin/shared/DashboardHeader.jsx
@@ -26,6 +26,7 @@ import {
   LogoutIcon,
   DesignServicesIcon,
   HandshakeIcon,
+  TrendingUpIcon,
 } from './icons';
 import MenuIcon from '@mui/icons-material/Menu';
 import useDeviceDetection from '../../../hooks/useDeviceDetection';
@@ -58,6 +59,7 @@ const DashboardHeader = () => {
     { text: 'Payments', icon: <PaymentIcon />, path: '/admin/payments' },
     { text: 'Clients', icon: <PeopleIcon />, path: '/admin/users' },
     { text: 'Suppliers', icon: <HandshakeIcon />, path: '/admin/suppliers' },
+    { text: 'Investments', icon: <TrendingUpIcon />, path: '/admin/investments' },
   ];
 
   // Contenido del drawer para móviles

--- a/src/components/admin/shared/icons.js
+++ b/src/components/admin/shared/icons.js
@@ -9,6 +9,7 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import HomeIcon from '@mui/icons-material/Home';
 import DesignServicesIcon from '@mui/icons-material/DesignServices';
 import HandshakeIcon from '@mui/icons-material/Handshake';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 
 export {
     DashboardIcon,
@@ -22,4 +23,5 @@ export {
     HomeIcon,
     DesignServicesIcon,
     HandshakeIcon,
-}; 
+    TrendingUpIcon,
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -37,7 +37,8 @@
       "cars": "Cars",
       "yachts": "Yachts",
       "apartments": "Apartments",
-      "villas": "Villas"
+      "villas": "Villas",
+      "investments": "Investments"
     },
     "brand": "Brand",
     "model": "Model",
@@ -169,5 +170,21 @@
       "title": "Contact us",
       "sending": "Sending...",
       "prefix": "Area"
+    },
+    "investments": {
+      "title": "Miami Investments",
+      "subtitle": "Exclusive properties selected to maximize your return on investment",
+      "priceOnRequest": "Price on request",
+      "rooms": "bedrooms",
+      "bathrooms": "bathrooms",
+      "unit": "Unit",
+      "inquire": "Inquire",
+      "whatsappMessage": "Hello, I would like to get more information about the investment in property {{name}}{{unit}} located at {{address}}.",
+      "backToInvestments": "Back to Investments",
+      "notFound": "Investment not found.",
+      "viewDetails": "View Details",
+      "noInvestments": "No investments available at this time.",
+      "loading": "Loading investments...",
+      "error": "Error loading investments. Please try again."
     }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -37,7 +37,8 @@
       "cars": "Autos",
       "yachts": "Yates",
       "apartments": "Departamentos",
-      "villas": "Villas"
+      "villas": "Villas",
+      "investments": "Inversiones"
     },
     "brand": "Marca",
     "model": "Modelo",
@@ -169,5 +170,21 @@
       "title": "Contactanos",
       "sending": "Enviando...",
       "prefix": "Area"
+    },
+    "investments": {
+      "title": "Inversiones en Miami",
+      "subtitle": "Propiedades exclusivas seleccionadas para maximizar tu retorno de inversión",
+      "priceOnRequest": "A consultar",
+      "rooms": "habitaciones",
+      "bathrooms": "baños",
+      "unit": "Unidad",
+      "inquire": "Consultar",
+      "whatsappMessage": "Hola, me gustaría obtener más información sobre la inversión en la propiedad {{name}}{{unit}} ubicada en {{address}}.",
+      "backToInvestments": "Volver a Inversiones",
+      "notFound": "Inversión no encontrada.",
+      "viewDetails": "Ver Detalles",
+      "noInvestments": "No hay inversiones disponibles en este momento.",
+      "loading": "Cargando inversiones...",
+      "error": "Error al cargar las inversiones. Por favor, intentá de nuevo."
     }
 }

--- a/src/pages/InvestmentDetailPage.jsx
+++ b/src/pages/InvestmentDetailPage.jsx
@@ -1,0 +1,197 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+    Box, Button, Card, CardContent, Chip, CircularProgress,
+    Container, Divider, Grid2, Typography, useMediaQuery, useTheme,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { motion } from 'framer-motion';
+import BathtubOutlinedIcon from '@mui/icons-material/BathtubOutlined';
+import BedOutlinedIcon from '@mui/icons-material/BedOutlined';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import WhatsAppIcon from '@mui/icons-material/WhatsApp';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import investmentService from '../services/investmentService';
+import ImageCarousel from '../components/images/ImageCarousel';
+
+const MotionCard = motion.create(Card);
+
+const InvestmentDetailPage = () => {
+    const { t } = useTranslation();
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+    const [investment, setInvestment] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetch = async () => {
+            try {
+                const data = await investmentService.getById(id);
+                setInvestment(data);
+            } catch (err) {
+                setError(err?.response?.status === 404
+                    ? t('investments.notFound')
+                    : t('investments.error')
+                );
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetch();
+    }, [id, t]);
+
+    const handleInquire = () => {
+        const phoneNumber = import.meta.env.VITE_WHATSAPP_NUMBER;
+        const unitPart = investment.unit_number ? ` — ${t('investments.unit')} ${investment.unit_number}` : '';
+        const message = t('investments.whatsappMessage', {
+            name: investment.name,
+            unit: unitPart,
+            address: investment.address,
+        });
+        window.open(`https://wa.me/${phoneNumber}?text=${encodeURIComponent(message)}`, '_blank');
+    };
+
+    const formatPrice = (price) =>
+        price === null || price === undefined
+            ? t('investments.priceOnRequest')
+            : `$${Number(price).toLocaleString('en-US')}`;
+
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }}>
+                <CircularProgress sx={{ color: '#6c5dd3' }} />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Container sx={{ py: 8, textAlign: 'center' }}>
+                <Typography color="error" gutterBottom>{error}</Typography>
+                <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/investments')}>
+                    {t('investments.backToInvestments')}
+                </Button>
+            </Container>
+        );
+    }
+
+    if (!investment) return null;
+
+    const images = Array.isArray(investment.images) ? investment.images : [];
+
+    return (
+        <Box sx={{ py: 4, minHeight: '100vh', mt: 8, bgcolor: 'background.default', color: 'text.primary' }}>
+            <Container maxWidth="md">
+                <MotionCard
+                    sx={{ width: '100%', mb: 4, bgcolor: 'background.paper', borderRadius: 2, overflow: 'hidden' }}
+                    initial={{ opacity: 0, y: 50 }}
+                    animate={{ opacity: 1, y: 0, transition: { type: 'spring', stiffness: 100, damping: 15 } }}
+                >
+                    {images.length > 0 && (
+                        <ImageCarousel
+                            images={images}
+                            width="95%"
+                            height={isMobile ? '250px' : '480px'}
+                            objectPosition="center center"
+                        />
+                    )}
+
+                    <CardContent sx={{ p: 4 }}>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+                            {/* Nombre y unidad */}
+                            <Box>
+                                <Typography variant="h4" fontWeight="bold" gutterBottom>
+                                    {investment.name}
+                                </Typography>
+                                {investment.unit_number && (
+                                    <Typography variant="subtitle1" sx={{ color: '#7c5cbf', fontWeight: 500 }}>
+                                        {t('investments.unit')} {investment.unit_number}
+                                    </Typography>
+                                )}
+                            </Box>
+
+                            {/* Dirección y características */}
+                            <Grid2 container spacing={2} alignItems="center">
+                                <Grid2 size={{ xs: 12 }}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <LocationOnIcon />
+                                        <Typography variant="body1">{investment.address}</Typography>
+                                    </Box>
+                                </Grid2>
+                                <Grid2 size={{ xs: 12, sm: 6 }}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <BedOutlinedIcon />
+                                        <Typography variant="body1">
+                                            {investment.rooms} {t('investments.rooms')}
+                                        </Typography>
+                                    </Box>
+                                </Grid2>
+                                <Grid2 size={{ xs: 12, sm: 6 }}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <BathtubOutlinedIcon />
+                                        <Typography variant="body1">
+                                            {investment.bathrooms} {t('investments.bathrooms')}
+                                        </Typography>
+                                    </Box>
+                                </Grid2>
+                            </Grid2>
+
+                            <Divider />
+
+                            {/* Descripción */}
+                            {investment.description && (
+                                <Box>
+                                    <Typography variant="h6" fontWeight="bold" gutterBottom>
+                                        {t('services.description')}
+                                    </Typography>
+                                    <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.8 }}>
+                                        {investment.description}
+                                    </Typography>
+                                </Box>
+                            )}
+
+                            {/* Precio y CTA */}
+                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 2, pt: 1 }}>
+                                <Typography variant="h5" fontWeight="bold" sx={{ color: '#6c5dd3' }}>
+                                    {formatPrice(investment.price)}
+                                </Typography>
+                                <Button
+                                    variant="contained"
+                                    size="large"
+                                    startIcon={<WhatsAppIcon />}
+                                    onClick={handleInquire}
+                                    sx={{
+                                        bgcolor: '#25D366',
+                                        color: '#fff',
+                                        '&:hover': { bgcolor: '#1da851' },
+                                        textTransform: 'none',
+                                        fontWeight: 600,
+                                        px: 3,
+                                    }}
+                                >
+                                    {t('investments.inquire')}
+                                </Button>
+                            </Box>
+                        </Box>
+                    </CardContent>
+                </MotionCard>
+
+                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                    <Button
+                        variant="contained"
+                        startIcon={<ArrowBackIcon />}
+                        onClick={() => navigate('/investments')}
+                    >
+                        {t('investments.backToInvestments')}
+                    </Button>
+                </Box>
+            </Container>
+        </Box>
+    );
+};
+
+export default InvestmentDetailPage;

--- a/src/pages/InvestmentsPage.jsx
+++ b/src/pages/InvestmentsPage.jsx
@@ -1,0 +1,235 @@
+import React, { useEffect } from 'react';
+import {
+    Box, Button, Card, CardContent, CardMedia, Chip,
+    CircularProgress, Container, Grid, Typography,
+} from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import BathtubOutlinedIcon from '@mui/icons-material/BathtubOutlined';
+import BedOutlinedIcon from '@mui/icons-material/BedOutlined';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import WhatsAppIcon from '@mui/icons-material/WhatsApp';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import {
+    fetchAllInvestments,
+    selectAllInvestments,
+    selectInvestmentsStatus,
+    selectInvestmentsError,
+} from '../redux/investmentSlice';
+
+const MotionCard = motion.create(Card);
+
+const cardVariants = {
+    hidden: { opacity: 0, y: 24 },
+    visible: (i) => ({
+        opacity: 1,
+        y: 0,
+        transition: { delay: i * 0.08, duration: 0.4, ease: 'easeOut' },
+    }),
+};
+
+const InvestmentsPage = () => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const investments = useSelector(selectAllInvestments);
+    const status = useSelector(selectInvestmentsStatus);
+    const error = useSelector(selectInvestmentsError);
+
+    useEffect(() => {
+        if (status === 'idle') dispatch(fetchAllInvestments());
+    }, [dispatch, status]);
+
+    const handleInquire = (inv) => {
+        const phoneNumber = import.meta.env.VITE_WHATSAPP_NUMBER;
+        const unitPart = inv.unit_number ? ` — ${t('investments.unit')} ${inv.unit_number}` : '';
+        const message = t('investments.whatsappMessage', {
+            name: inv.name,
+            unit: unitPart,
+            address: inv.address,
+        });
+        window.open(`https://wa.me/${phoneNumber}?text=${encodeURIComponent(message)}`, '_blank');
+    };
+
+    const formatPrice = (price) =>
+        price === null || price === undefined
+            ? t('investments.priceOnRequest')
+            : `$${Number(price).toLocaleString('en-US')}`;
+
+    return (
+        <Box sx={{ minHeight: '100vh', bgcolor: '#0e0e0e', pb: 8 }}>
+            {/* Hero */}
+            <Box
+                sx={{
+                    background: 'linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%)',
+                    py: { xs: 6, md: 10 },
+                    textAlign: 'center',
+                    px: 2,
+                }}
+            >
+                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 1.5, mb: 2 }}>
+                    <TrendingUpIcon sx={{ fontSize: 40, color: '#6c5dd3' }} />
+                    <Typography
+                        variant="h3"
+                        sx={{ fontWeight: 700, color: '#fff', fontSize: { xs: '2rem', md: '3rem' } }}
+                    >
+                        {t('investments.title')}
+                    </Typography>
+                </Box>
+                <Typography variant="h6" sx={{ color: '#aaa', maxWidth: 600, mx: 'auto', fontWeight: 400 }}>
+                    {t('investments.subtitle')}
+                </Typography>
+            </Box>
+
+            <Container maxWidth="lg" sx={{ mt: 6 }}>
+                {status === 'loading' && (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
+                        <CircularProgress sx={{ color: '#6c5dd3' }} />
+                    </Box>
+                )}
+
+                {status === 'failed' && (
+                    <Box sx={{ textAlign: 'center', py: 10 }}>
+                        <Typography sx={{ color: '#ef5350' }}>{error || t('investments.error')}</Typography>
+                    </Box>
+                )}
+
+                {status === 'succeeded' && investments.length === 0 && (
+                    <Box sx={{ textAlign: 'center', py: 10 }}>
+                        <TrendingUpIcon sx={{ fontSize: 64, color: '#333', mb: 2 }} />
+                        <Typography sx={{ color: '#666' }}>{t('investments.noInvestments')}</Typography>
+                    </Box>
+                )}
+
+                {status === 'succeeded' && investments.length > 0 && (
+                    <Grid container spacing={3}>
+                        {investments.map((inv, i) => (
+                            <Grid item xs={12} sm={6} md={4} key={inv.id}>
+                                <MotionCard
+                                    custom={i}
+                                    initial="hidden"
+                                    animate="visible"
+                                    variants={cardVariants}
+                                    onClick={() => navigate(`/investments/${inv.id}`)}
+                                    sx={{
+                                        bgcolor: '#1a1a1a',
+                                        border: '1px solid #2a2a2a',
+                                        borderRadius: 2,
+                                        height: '100%',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        cursor: 'pointer',
+                                        transition: 'border-color 0.2s, transform 0.2s',
+                                        '&:hover': {
+                                            borderColor: '#6c5dd3',
+                                            transform: 'translateY(-4px)',
+                                        },
+                                    }}
+                                >
+                                    {inv.images?.[0] ? (
+                                        <CardMedia
+                                            component="img"
+                                            height="220"
+                                            image={inv.images[0]}
+                                            alt={inv.name}
+                                            sx={{ objectFit: 'cover' }}
+                                        />
+                                    ) : (
+                                        <Box
+                                            sx={{
+                                                height: 220,
+                                                bgcolor: '#252525',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                            }}
+                                        >
+                                            <TrendingUpIcon sx={{ fontSize: 48, color: '#333' }} />
+                                        </Box>
+                                    )}
+
+                                    <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                                        <Box>
+                                            <Typography variant="h6" sx={{ color: '#fff', fontWeight: 600, lineHeight: 1.3 }}>
+                                                {inv.name}
+                                            </Typography>
+                                            {inv.unit_number && (
+                                                <Typography variant="body2" sx={{ color: '#7c5cbf', fontWeight: 500 }}>
+                                                    {t('investments.unit')} {inv.unit_number}
+                                                </Typography>
+                                            )}
+                                        </Box>
+
+                                        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+                                            <LocationOnIcon sx={{ fontSize: 16, color: '#666', mt: 0.2, flexShrink: 0 }} />
+                                            <Typography variant="body2" sx={{ color: '#888', lineHeight: 1.4 }}>
+                                                {inv.address}
+                                            </Typography>
+                                        </Box>
+
+                                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                                            <Chip
+                                                icon={<BedOutlinedIcon sx={{ fontSize: '16px !important' }} />}
+                                                label={`${inv.rooms} ${t('investments.rooms')}`}
+                                                size="small"
+                                                sx={{ bgcolor: '#252525', color: '#ccc', border: '1px solid #333' }}
+                                            />
+                                            <Chip
+                                                icon={<BathtubOutlinedIcon sx={{ fontSize: '16px !important' }} />}
+                                                label={`${inv.bathrooms} ${t('investments.bathrooms')}`}
+                                                size="small"
+                                                sx={{ bgcolor: '#252525', color: '#ccc', border: '1px solid #333' }}
+                                            />
+                                        </Box>
+
+                                        {inv.description && (
+                                            <Typography
+                                                variant="body2"
+                                                sx={{
+                                                    color: '#777',
+                                                    display: '-webkit-box',
+                                                    WebkitLineClamp: 2,
+                                                    WebkitBoxOrient: 'vertical',
+                                                    overflow: 'hidden',
+                                                }}
+                                            >
+                                                {inv.description}
+                                            </Typography>
+                                        )}
+
+                                        <Typography variant="h6" sx={{ color: '#6c5dd3', fontWeight: 700, mt: 'auto', pt: 1 }}>
+                                            {formatPrice(inv.price)}
+                                        </Typography>
+
+                                        <Box sx={{ display: 'flex', gap: 1 }}>
+                                            <Button
+                                                variant="contained"
+                                                size="small"
+                                                fullWidth
+                                                startIcon={<WhatsAppIcon />}
+                                                onClick={(e) => { e.stopPropagation(); handleInquire(inv); }}
+                                                sx={{
+                                                    bgcolor: '#25D366',
+                                                    color: '#fff',
+                                                    '&:hover': { bgcolor: '#1da851' },
+                                                    textTransform: 'none',
+                                                    fontWeight: 600,
+                                                }}
+                                            >
+                                                {t('investments.inquire')}
+                                            </Button>
+                                        </Box>
+                                    </CardContent>
+                                </MotionCard>
+                            </Grid>
+                        ))}
+                    </Grid>
+                )}
+            </Container>
+        </Box>
+    );
+};
+
+export default InvestmentsPage;

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -20,6 +20,7 @@ const services = [
   { id: 2, nameKey: 'services.types.yachts', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024229/utils/Services/yacht.png', path: '/services/yachts' },
   { id: 3, nameKey: 'services.types.apartments', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024735/utils/Services/apartment.png', path: '/services/apartments' },
   { id: 4, nameKey: 'services.types.villas', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024225/utils/Services/villa.png', path: '/services/villas' },
+  { id: 5, nameKey: 'services.types.investments', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024225/utils/Services/villa.png', path: '/investments' },
 ];
 
 const MotionGrid = motion.create(Grid);

--- a/src/redux/investmentSlice.js
+++ b/src/redux/investmentSlice.js
@@ -1,0 +1,97 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import investmentService from '../services/investmentService';
+
+export const fetchAllInvestments = createAsyncThunk(
+    'investments/fetchAll',
+    async (_, { rejectWithValue }) => {
+        try {
+            return await investmentService.getAll();
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error fetching investments');
+        }
+    }
+);
+
+export const createInvestment = createAsyncThunk(
+    'investments/create',
+    async (formData, { rejectWithValue }) => {
+        try {
+            return await investmentService.create(formData);
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error creating investment');
+        }
+    }
+);
+
+export const updateInvestment = createAsyncThunk(
+    'investments/update',
+    async ({ id, formData }, { rejectWithValue }) => {
+        try {
+            return await investmentService.update(id, formData);
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error updating investment');
+        }
+    }
+);
+
+export const deleteInvestment = createAsyncThunk(
+    'investments/delete',
+    async (id, { rejectWithValue }) => {
+        try {
+            await investmentService.delete(id);
+            return id;
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error deleting investment');
+        }
+    }
+);
+
+const investmentSlice = createSlice({
+    name: 'investments',
+    initialState: { investments: [], status: 'idle', error: null },
+    reducers: {
+        clearError: (state) => { state.error = null; },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchAllInvestments.pending, (state) => {
+                state.status = 'loading';
+                state.error = null;
+            })
+            .addCase(fetchAllInvestments.fulfilled, (state, action) => {
+                state.status = 'succeeded';
+                state.investments = action.payload;
+            })
+            .addCase(fetchAllInvestments.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload;
+            })
+            .addCase(createInvestment.fulfilled, (state, action) => {
+                state.investments.unshift(action.payload);
+            })
+            .addCase(createInvestment.rejected, (state, action) => {
+                state.error = action.payload;
+            })
+            .addCase(updateInvestment.fulfilled, (state, action) => {
+                const idx = state.investments.findIndex(i => i.id === action.payload.id);
+                if (idx !== -1) state.investments[idx] = action.payload;
+            })
+            .addCase(updateInvestment.rejected, (state, action) => {
+                state.error = action.payload;
+            })
+            .addCase(deleteInvestment.fulfilled, (state, action) => {
+                state.investments = state.investments.filter(i => i.id !== action.payload);
+            })
+            .addCase(deleteInvestment.rejected, (state, action) => {
+                state.error = action.payload;
+            });
+    },
+});
+
+export const { clearError } = investmentSlice.actions;
+
+export const selectAllInvestments = (state) => state.investments.investments;
+export const selectInvestmentsStatus = (state) => state.investments.status;
+export const selectInvestmentsError = (state) => state.investments.error;
+
+export default investmentSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -8,6 +8,7 @@ import reservationReducer from './reservationSlice';
 import reservationPaymentReducer from './reservationPaymentSlice';
 import summaryReducer from './summarySlice';
 import supplierReducer from './supplierSlice';
+import investmentReducer from './investmentSlice';
 
 export const store = configureStore({
     reducer: {
@@ -20,6 +21,7 @@ export const store = configureStore({
         reservationPayments: reservationPaymentReducer,
         summary: summaryReducer,
         suppliers: supplierReducer,
+        investments: investmentReducer,
     },
 });
 

--- a/src/services/investmentService.js
+++ b/src/services/investmentService.js
@@ -1,0 +1,30 @@
+import api from '../utils/api';
+
+const investmentService = {
+    getAll: async () => {
+        const res = await api.get('/investments');
+        return res.data;
+    },
+
+    getById: async (id) => {
+        const res = await api.get(`/investments/${id}`);
+        return res.data;
+    },
+
+    create: async (formData) => {
+        const res = await api.post('/investments', formData);
+        return res.data;
+    },
+
+    update: async (id, formData) => {
+        const res = await api.put(`/investments/${id}`, formData);
+        return res.data;
+    },
+
+    delete: async (id) => {
+        const res = await api.delete(`/investments/${id}`);
+        return res.data;
+    },
+};
+
+export default investmentService;


### PR DESCRIPTION
## Summary

- **Página pública** `/investments`: grid de propiedades, card entera clickeable al detalle, botón WhatsApp por card con mensaje que aclara que es consulta de inversión
- **Página de detalle** `/investments/:id`: ImageCarousel, descripción completa, precio ("A consultar" si es null), botón WhatsApp
- **Panel admin** `/admin/investments`: CRUD completo con upload de imágenes, tabla desktop / cards mobile
- **Services page**: 5ª card de inversiones en la grilla pública (imagen placeholder, reemplazar con imagen definitiva en Cloudinary)
- **Redux**: `investmentSlice` + registro en store
- **i18n**: claves `investments.*` en ES y EN; mensaje WhatsApp generado en el idioma activo del sitio

## Notas

- Imagen de la card en Services.jsx usa villa como placeholder — reemplazar URL cuando esté la imagen definitiva
- No hay ruta `/services/investments`; investments vive en `/investments` por tener estructura de datos y UX distinta a los servicios de alquiler
- PUT con imágenes nuevas reemplaza todas las existentes en Cloudinary; sin imágenes, las existentes se mantienen

## Test plan

- [x] `/investments` muestra el listado y cada card navega al detalle al clickear
- [x] Botón WhatsApp en listado abre con mensaje correcto sin navegar al detalle
- [x] `/investments/:id` muestra el detalle con imágenes, datos y botón WhatsApp
- [x] `/admin/investments` permite crear, editar y eliminar inversiones
- [x] Card de Investments aparece en la sección "Nuestros Servicios" del home

🤖 Generated with [Claude Code](https://claude.com/claude-code)