### PR TITLE
feat: add experiences feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,10 @@ const SupplierList = lazy(() => import('./components/admin/suppliers/SupplierLis
 const InvestmentsPage = lazy(() => import('./pages/InvestmentsPage'));
 const InvestmentDetailPage = lazy(() => import('./pages/InvestmentDetailPage'));
 const InvestmentList = lazy(() => import('./components/admin/investments/InvestmentList'));
+const ExperiencesPage = lazy(() => import('./pages/ExperiencesPage'));
+const ExperienceDetailPage = lazy(() => import('./pages/ExperienceDetailPage'));
+const ExperienceList = lazy(() => import('./components/admin/experiences/ExperienceList'));
+const InquiryList = lazy(() => import('./components/admin/experiences/InquiryList'));
 
 const theme = createTheme({
   palette: {
@@ -111,9 +115,13 @@ function AppContent() {
               <Route path="apartments" element={<ApartmentList />} />
               <Route path="suppliers" element={<SupplierList />} />
               <Route path="investments" element={<InvestmentList />} />
+              <Route path="experiences" element={<ExperienceList />} />
+              <Route path="experiences/inquiries" element={<InquiryList />} />
             </Route>
             <Route path="/investments" element={<InvestmentsPage />} />
             <Route path="/investments/:id" element={<InvestmentDetailPage />} />
+            <Route path="/experiences" element={<ExperiencesPage />} />
+            <Route path="/experiences/:id" element={<ExperienceDetailPage />} />
             <Route path="/reservations" element={<ReservationsPage />} />
             <Route path="/reservations/:id" element={<ReservationDetailsPage />} />
           </Routes>

--- a/src/components/admin/experiences/ExperienceList.jsx
+++ b/src/components/admin/experiences/ExperienceList.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
     Box, Button, Card, CardActions, CardContent, CardMedia, Chip,
     CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
-    Divider, Grid, IconButton, Paper, Skeleton,
+    Divider, Grid, IconButton, Paper, Skeleton, Tab, Tabs,
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
     TextField, Tooltip, Typography,
 } from '@mui/material';
@@ -13,12 +13,15 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import ExploreIcon from '@mui/icons-material/Explore';
 import GroupIcon from '@mui/icons-material/Group';
 import ImageIcon from '@mui/icons-material/Image';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import {
     fetchAllExperiences, createExperience, updateExperience, deleteExperience,
     selectAllExperiences, selectExperiencesStatus,
 } from '../../../redux/experienceSlice';
+import { selectAllInquiries, selectInquiriesStatus } from '../../../redux/experienceInquirySlice';
 import DeleteDialog from '../dialogs/DeleteDialog';
 import useDeviceDetection from '../../../hooks/useDeviceDetection';
+import InquiryList from './InquiryList';
 
 const fieldSx = {
     '& .MuiOutlinedInput-root': {
@@ -95,7 +98,10 @@ const ExperienceList = () => {
     const { isMobile, isTablet } = useDeviceDetection();
     const experiences = useSelector(selectAllExperiences);
     const status = useSelector(selectExperiencesStatus);
+    const inquiries = useSelector(selectAllInquiries);
+    const pendingCount = inquiries.filter(i => i.status === 'pending').length;
 
+    const [activeTab, setActiveTab] = useState(0);
     const [createOpen, setCreateOpen] = useState(false);
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -224,7 +230,30 @@ const ExperienceList = () => {
     }
 
     return (
-        <Box sx={{ p: 3 }}>
+        <Box>
+            {/* Tabs */}
+            <Box sx={{ borderBottom: '1px solid #2a2a2a', px: 3, pt: 2 }}>
+                <Tabs
+                    value={activeTab}
+                    onChange={(_, v) => setActiveTab(v)}
+                    sx={{
+                        '& .MuiTab-root': { color: '#888', textTransform: 'none', fontWeight: 600 },
+                        '& .Mui-selected': { color: '#4fc3f7' },
+                        '& .MuiTabs-indicator': { bgcolor: '#4fc3f7' },
+                    }}
+                >
+                    <Tab icon={<ExploreIcon />} iconPosition="start" label="Experiences" />
+                    <Tab
+                        icon={<MailOutlineIcon />}
+                        iconPosition="start"
+                        label={pendingCount > 0 ? `Inquiries (${pendingCount} pending)` : 'Inquiries'}
+                    />
+                </Tabs>
+            </Box>
+
+            {activeTab === 1 && <InquiryList />}
+
+            {activeTab === 0 && <Box sx={{ p: 3 }}>
             {/* Header */}
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -437,6 +466,7 @@ const ExperienceList = () => {
                 onClose={() => { setDeleteOpen(false); setSelected(null); }}
                 onConfirm={handleDelete}
             />
+        </Box>}
         </Box>
     );
 };

--- a/src/components/admin/experiences/ExperienceList.jsx
+++ b/src/components/admin/experiences/ExperienceList.jsx
@@ -1,0 +1,444 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+    Box, Button, Card, CardActions, CardContent, CardMedia, Chip,
+    CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
+    Divider, Grid, IconButton, Paper, Skeleton,
+    Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+    TextField, Tooltip, Typography,
+} from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ExploreIcon from '@mui/icons-material/Explore';
+import GroupIcon from '@mui/icons-material/Group';
+import ImageIcon from '@mui/icons-material/Image';
+import {
+    fetchAllExperiences, createExperience, updateExperience, deleteExperience,
+    selectAllExperiences, selectExperiencesStatus,
+} from '../../../redux/experienceSlice';
+import DeleteDialog from '../dialogs/DeleteDialog';
+import useDeviceDetection from '../../../hooks/useDeviceDetection';
+
+const fieldSx = {
+    '& .MuiOutlinedInput-root': {
+        bgcolor: '#252525',
+        '& fieldset': { borderColor: '#3a3a3a' },
+        '&:hover fieldset': { borderColor: '#555' },
+        '&.Mui-focused fieldset': { borderColor: '#4fc3f7' },
+    },
+    '& .MuiInputLabel-root': { color: '#777' },
+    '& .MuiInputBase-input': { color: '#fff' },
+};
+
+const emptyForm = { title: '', description: '', capacity: '', price: '' };
+
+const formatPrice = (price) =>
+    price === null || price === undefined
+        ? 'Price on request'
+        : `$${Number(price).toLocaleString('en-US')}`;
+
+const ExperienceForm = ({ form, onChange, imageFiles, onImageChange, isEdit }) => (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+        <TextField
+            label="Title *" name="title" value={form.title}
+            onChange={onChange} fullWidth sx={fieldSx}
+        />
+        <TextField
+            label="Description" name="description" value={form.description}
+            onChange={onChange} fullWidth multiline rows={3} sx={fieldSx}
+        />
+        <Box sx={{ display: 'flex', gap: 2 }}>
+            <TextField
+                label="Capacity (leave empty = unlimited)" name="capacity" value={form.capacity} type="number"
+                onChange={onChange} fullWidth sx={fieldSx}
+                inputProps={{ min: 1 }}
+            />
+            <TextField
+                label="Price (leave empty = on request)" name="price" value={form.price} type="number"
+                onChange={onChange} fullWidth sx={fieldSx}
+                inputProps={{ min: 0 }}
+            />
+        </Box>
+        <Box>
+            <Button
+                component="label"
+                variant="outlined"
+                startIcon={<ImageIcon />}
+                sx={{ color: '#aaa', borderColor: '#3a3a3a', '&:hover': { borderColor: '#4fc3f7' } }}
+            >
+                {imageFiles.length > 0 ? `${imageFiles.length} image(s) selected` : 'Select images'}
+                <input
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    hidden
+                    onChange={onImageChange}
+                />
+            </Button>
+            {isEdit && imageFiles.length === 0 && (
+                <Typography variant="caption" sx={{ color: '#777', display: 'block', mt: 0.5 }}>
+                    Leave empty to keep existing images. Uploading new images replaces all existing ones.
+                </Typography>
+            )}
+            {imageFiles.length > 0 && (
+                <Typography variant="caption" sx={{ color: '#aaa', display: 'block', mt: 0.5 }}>
+                    {imageFiles.map(f => f.name).join(', ')}
+                </Typography>
+            )}
+        </Box>
+    </Box>
+);
+
+const ExperienceList = () => {
+    const dispatch = useDispatch();
+    const { isMobile, isTablet } = useDeviceDetection();
+    const experiences = useSelector(selectAllExperiences);
+    const status = useSelector(selectExperiencesStatus);
+
+    const [createOpen, setCreateOpen] = useState(false);
+    const [editOpen, setEditOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [selected, setSelected] = useState(null);
+    const [form, setForm] = useState(emptyForm);
+    const [imageFiles, setImageFiles] = useState([]);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        if (status === 'idle') dispatch(fetchAllExperiences());
+    }, [dispatch, status]);
+
+    const handleFormChange = (e) => {
+        const { name, value } = e.target;
+        setForm(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleImageChange = (e) => {
+        const files = Array.from(e.target.files).slice(0, 30);
+        setImageFiles(files);
+    };
+
+    const buildFormData = () => {
+        const fd = new FormData();
+        fd.append('title', form.title.trim());
+        if (form.description.trim()) fd.append('description', form.description.trim());
+        if (form.capacity !== '') fd.append('capacity', form.capacity);
+        if (form.price !== '') fd.append('price', form.price);
+        imageFiles.forEach(file => fd.append('images', file));
+        return fd;
+    };
+
+    const isFormValid = () => form.title.trim().length > 0;
+
+    const openCreate = () => {
+        setForm(emptyForm);
+        setImageFiles([]);
+        setCreateOpen(true);
+    };
+
+    const openEdit = (exp) => {
+        setSelected(exp);
+        setForm({
+            title: exp.title || '',
+            description: exp.description || '',
+            capacity: exp.capacity ?? '',
+            price: exp.price ?? '',
+        });
+        setImageFiles([]);
+        setEditOpen(true);
+    };
+
+    const openDelete = (exp) => {
+        setSelected(exp);
+        setDeleteOpen(true);
+    };
+
+    const handleCreate = async () => {
+        if (!isFormValid()) return;
+        setSaving(true);
+        try {
+            await dispatch(createExperience(buildFormData())).unwrap();
+            setCreateOpen(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleEdit = async () => {
+        if (!isFormValid() || !selected) return;
+        setSaving(true);
+        try {
+            await dispatch(updateExperience({ id: selected.id, formData: buildFormData() })).unwrap();
+            setEditOpen(false);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!selected) return;
+        try {
+            await dispatch(deleteExperience(selected.id)).unwrap();
+            setDeleteOpen(false);
+            setSelected(null);
+        } catch {
+            // handled by slice
+        }
+    };
+
+    const dialogProps = {
+        maxWidth: 'sm',
+        fullWidth: true,
+        PaperProps: { sx: { bgcolor: '#1a1a1a', color: '#fff' } },
+    };
+
+    if (status === 'loading') {
+        return (
+            <Box sx={{ p: 3 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                    <Skeleton variant="text" width={180} height={40} />
+                    <Skeleton variant="rectangular" width={160} height={36} />
+                </Box>
+                <TableContainer component={Paper} sx={{ bgcolor: '#1e1e1e' }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                {['Experience', 'Capacity', 'Price', 'Actions'].map(h => (
+                                    <TableCell key={h}>{h}</TableCell>
+                                ))}
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {[...Array(4)].map((_, i) => (
+                                <TableRow key={i}>
+                                    {[200, 100, 120, 80].map((w, j) => (
+                                        <TableCell key={j}><Skeleton variant="text" width={w} /></TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ p: 3 }}>
+            {/* Header */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <ExploreIcon sx={{ color: '#4fc3f7' }} />
+                    <Typography variant="h4">Experiences</Typography>
+                </Box>
+                <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={openCreate}
+                    sx={{ bgcolor: '#4fc3f7', color: '#000', '&:hover': { bgcolor: '#0288d1', color: '#fff' } }}
+                >
+                    New Experience
+                </Button>
+            </Box>
+
+            {experiences.length === 0 ? (
+                <Box sx={{ textAlign: 'center', py: 8, color: '#666' }}>
+                    <ExploreIcon sx={{ fontSize: 48, mb: 1, color: '#333' }} />
+                    <Typography variant="body1">No experiences yet.</Typography>
+                    <Typography variant="body2" sx={{ mt: 0.5 }}>Click "+ New Experience" to add the first one.</Typography>
+                </Box>
+            ) : isMobile || isTablet ? (
+                <Grid container spacing={2}>
+                    {experiences.map(exp => (
+                        <Grid item xs={12} sm={6} key={exp.id}>
+                            <Card sx={{ bgcolor: '#2a2a2a', border: '1px solid #333' }}>
+                                {exp.images?.[0] && (
+                                    <CardMedia
+                                        component="img"
+                                        height="160"
+                                        image={exp.images[0]}
+                                        alt={exp.title}
+                                        sx={{ objectFit: 'cover' }}
+                                    />
+                                )}
+                                <CardContent>
+                                    <Typography variant="h6" sx={{ color: '#fff' }}>{exp.title}</Typography>
+                                    {exp.capacity !== null && exp.capacity !== undefined && (
+                                        <Chip
+                                            icon={<GroupIcon />}
+                                            label={`${exp.capacity} people`}
+                                            size="small"
+                                            sx={{ bgcolor: '#333', color: '#ddd', mt: 1, mb: 1 }}
+                                        />
+                                    )}
+                                    <Typography variant="body1" sx={{ color: '#4fc3f7', fontWeight: 600 }}>
+                                        {formatPrice(exp.price)}
+                                    </Typography>
+                                </CardContent>
+                                <Divider sx={{ borderColor: '#333' }} />
+                                <CardActions sx={{ justifyContent: 'flex-end', p: 1 }}>
+                                    <IconButton size="small" onClick={() => openEdit(exp)} sx={{ color: '#4fc3f7' }}>
+                                        <EditIcon />
+                                    </IconButton>
+                                    <IconButton size="small" onClick={() => openDelete(exp)} color="error">
+                                        <DeleteIcon />
+                                    </IconButton>
+                                </CardActions>
+                            </Card>
+                        </Grid>
+                    ))}
+                </Grid>
+            ) : (
+                <TableContainer component={Paper} sx={{ bgcolor: '#1e1e1e' }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow sx={{ '& th': { color: '#aaa', fontWeight: 600, borderColor: '#333' } }}>
+                                <TableCell>Experience</TableCell>
+                                <TableCell>Capacity</TableCell>
+                                <TableCell>Price</TableCell>
+                                <TableCell>Actions</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {experiences.map(exp => (
+                                <TableRow
+                                    key={exp.id}
+                                    sx={{ '&:hover': { bgcolor: '#2a2a2a' }, '& td': { borderColor: '#2a2a2a', color: '#ddd' } }}
+                                >
+                                    <TableCell>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                                            {exp.images?.[0] ? (
+                                                <Box
+                                                    component="img"
+                                                    src={exp.images[0]}
+                                                    alt={exp.title}
+                                                    sx={{ width: 48, height: 36, borderRadius: 1, objectFit: 'cover', flexShrink: 0 }}
+                                                />
+                                            ) : (
+                                                <Box sx={{
+                                                    width: 48, height: 36, borderRadius: 1, bgcolor: '#333',
+                                                    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                                                }}>
+                                                    <ImageIcon sx={{ fontSize: 16, color: '#555' }} />
+                                                </Box>
+                                            )}
+                                            <Box>
+                                                <Typography variant="body2" sx={{ color: '#fff', fontWeight: 500 }}>
+                                                    {exp.title}
+                                                </Typography>
+                                                {exp.description && (
+                                                    <Typography variant="caption" sx={{
+                                                        color: '#777',
+                                                        display: '-webkit-box',
+                                                        WebkitLineClamp: 1,
+                                                        WebkitBoxOrient: 'vertical',
+                                                        overflow: 'hidden',
+                                                        maxWidth: 280,
+                                                    }}>
+                                                        {exp.description}
+                                                    </Typography>
+                                                )}
+                                            </Box>
+                                        </Box>
+                                    </TableCell>
+                                    <TableCell>
+                                        {exp.capacity !== null && exp.capacity !== undefined ? (
+                                            <Chip
+                                                icon={<GroupIcon />}
+                                                label={`${exp.capacity} people`}
+                                                size="small"
+                                                sx={{ bgcolor: '#333', color: '#ddd' }}
+                                            />
+                                        ) : (
+                                            <Typography variant="caption" sx={{ color: '#555' }}>Unlimited</Typography>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Typography variant="body2" sx={{ color: '#4fc3f7', fontWeight: 600 }}>
+                                            {formatPrice(exp.price)}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>
+                                        <Tooltip title="Edit">
+                                            <IconButton size="small" onClick={() => openEdit(exp)} sx={{ color: '#4fc3f7' }}>
+                                                <EditIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Delete">
+                                            <IconButton size="small" onClick={() => openDelete(exp)} color="error">
+                                                <DeleteIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            )}
+
+            {/* Create dialog */}
+            <Dialog open={createOpen} onClose={() => setCreateOpen(false)} {...dialogProps}>
+                <DialogTitle sx={{ borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <ExploreIcon sx={{ color: '#4fc3f7' }} />
+                    New Experience
+                </DialogTitle>
+                <DialogContent sx={{ pt: 2 }}>
+                    <ExperienceForm
+                        form={form} onChange={handleFormChange}
+                        imageFiles={imageFiles} onImageChange={handleImageChange}
+                        isEdit={false}
+                    />
+                </DialogContent>
+                <DialogActions sx={{ borderTop: '1px solid #333', px: 3, py: 2 }}>
+                    <Button onClick={() => setCreateOpen(false)} sx={{ color: '#aaa' }}>Cancel</Button>
+                    <Button
+                        onClick={handleCreate}
+                        disabled={saving || !isFormValid()}
+                        variant="contained"
+                        sx={{ bgcolor: '#4fc3f7', color: '#000', '&:hover': { bgcolor: '#0288d1', color: '#fff' } }}
+                        startIcon={saving ? <CircularProgress size={14} color="inherit" /> : null}
+                    >
+                        {saving ? 'Saving…' : 'Create'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Edit dialog */}
+            <Dialog open={editOpen} onClose={() => setEditOpen(false)} {...dialogProps}>
+                <DialogTitle sx={{ borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <EditIcon sx={{ color: '#4fc3f7' }} />
+                    Edit Experience
+                </DialogTitle>
+                <DialogContent sx={{ pt: 2 }}>
+                    <ExperienceForm
+                        form={form} onChange={handleFormChange}
+                        imageFiles={imageFiles} onImageChange={handleImageChange}
+                        isEdit
+                    />
+                </DialogContent>
+                <DialogActions sx={{ borderTop: '1px solid #333', px: 3, py: 2 }}>
+                    <Button onClick={() => setEditOpen(false)} sx={{ color: '#aaa' }}>Cancel</Button>
+                    <Button
+                        onClick={handleEdit}
+                        disabled={saving || !isFormValid()}
+                        variant="contained"
+                        sx={{ bgcolor: '#4fc3f7', color: '#000', '&:hover': { bgcolor: '#0288d1', color: '#fff' } }}
+                        startIcon={saving ? <CircularProgress size={14} color="inherit" /> : null}
+                    >
+                        {saving ? 'Saving…' : 'Save Changes'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Delete dialog */}
+            <DeleteDialog
+                open={deleteOpen}
+                onClose={() => { setDeleteOpen(false); setSelected(null); }}
+                onConfirm={handleDelete}
+            />
+        </Box>
+    );
+};
+
+export default ExperienceList;

--- a/src/components/admin/experiences/InquiryList.jsx
+++ b/src/components/admin/experiences/InquiryList.jsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Box, Chip, CircularProgress, MenuItem, Paper, Select, Skeleton,
+    Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+    Typography,
+} from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
+import {
+    fetchAllInquiries, updateInquiryStatus,
+    selectAllInquiries, selectInquiriesStatus,
+} from '../../../redux/experienceInquirySlice';
+
+const STATUS_COLORS = {
+    pending: { bgcolor: '#1a3a1a', color: '#66bb6a', border: '#2a5a2a' },
+    contacted: { bgcolor: '#1a2a3a', color: '#4fc3f7', border: '#2a4a6a' },
+    closed: { bgcolor: '#2a2a2a', color: '#888', border: '#3a3a3a' },
+};
+
+const StatusChip = ({ status }) => {
+    const colors = STATUS_COLORS[status] || STATUS_COLORS.pending;
+    return (
+        <Chip
+            label={status}
+            size="small"
+            sx={{
+                bgcolor: colors.bgcolor,
+                color: colors.color,
+                border: `1px solid ${colors.border}`,
+                textTransform: 'capitalize',
+                fontWeight: 600,
+            }}
+        />
+    );
+};
+
+const InquiryList = () => {
+    const dispatch = useDispatch();
+    const inquiries = useSelector(selectAllInquiries);
+    const status = useSelector(selectInquiriesStatus);
+    const [updating, setUpdating] = useState(null);
+
+    useEffect(() => {
+        if (status === 'idle') dispatch(fetchAllInquiries());
+    }, [dispatch, status]);
+
+    const handleStatusChange = async (id, newStatus) => {
+        setUpdating(id);
+        try {
+            await dispatch(updateInquiryStatus({ id, status: newStatus })).unwrap();
+        } finally {
+            setUpdating(null);
+        }
+    };
+
+    if (status === 'loading') {
+        return (
+            <Box sx={{ p: 3 }}>
+                <Skeleton variant="text" width={200} height={40} sx={{ mb: 3 }} />
+                <TableContainer component={Paper} sx={{ bgcolor: '#1e1e1e' }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                {['Contact', 'Experience', 'Phone', 'Status', 'Date'].map(h => (
+                                    <TableCell key={h}>{h}</TableCell>
+                                ))}
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {[...Array(5)].map((_, i) => (
+                                <TableRow key={i}>
+                                    {[180, 160, 120, 100, 120].map((w, j) => (
+                                        <TableCell key={j}><Skeleton variant="text" width={w} /></TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ p: 3 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+                <MailOutlineIcon sx={{ color: '#4fc3f7' }} />
+                <Typography variant="h4">Inquiries</Typography>
+                {inquiries.length > 0 && (
+                    <Chip
+                        label={inquiries.filter(i => i.status === 'pending').length + ' pending'}
+                        size="small"
+                        sx={{ bgcolor: '#1a3a1a', color: '#66bb6a', border: '1px solid #2a5a2a', ml: 1 }}
+                    />
+                )}
+            </Box>
+
+            {inquiries.length === 0 ? (
+                <Box sx={{ textAlign: 'center', py: 8, color: '#666' }}>
+                    <MailOutlineIcon sx={{ fontSize: 48, mb: 1, color: '#333' }} />
+                    <Typography variant="body1">No inquiries yet.</Typography>
+                </Box>
+            ) : (
+                <TableContainer component={Paper} sx={{ bgcolor: '#1e1e1e' }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow sx={{ '& th': { color: '#aaa', fontWeight: 600, borderColor: '#333' } }}>
+                                <TableCell>Contact</TableCell>
+                                <TableCell>Experience</TableCell>
+                                <TableCell>Phone</TableCell>
+                                <TableCell>Status</TableCell>
+                                <TableCell>Date</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {inquiries.map(inq => (
+                                <TableRow
+                                    key={inq.id}
+                                    sx={{ '&:hover': { bgcolor: '#2a2a2a' }, '& td': { borderColor: '#2a2a2a', color: '#ddd' } }}
+                                >
+                                    <TableCell>
+                                        <Typography variant="body2" sx={{ color: '#fff', fontWeight: 500 }}>
+                                            {inq.name} {inq.lastname}
+                                        </Typography>
+                                        <Typography variant="caption" sx={{ color: '#777' }}>
+                                            {inq.email}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>
+                                        {inq.experience_title ? (
+                                            <Typography variant="body2">{inq.experience_title}</Typography>
+                                        ) : (
+                                            <Typography variant="caption" sx={{ color: '#555', fontStyle: 'italic' }}>
+                                                General inquiry
+                                            </Typography>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Typography variant="body2" sx={{ color: inq.phone ? '#ddd' : '#555' }}>
+                                            {inq.phone || '—'}
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell>
+                                        {updating === inq.id ? (
+                                            <CircularProgress size={20} sx={{ color: '#4fc3f7' }} />
+                                        ) : (
+                                            <Select
+                                                value={inq.status}
+                                                onChange={(e) => handleStatusChange(inq.id, e.target.value)}
+                                                size="small"
+                                                sx={{
+                                                    color: STATUS_COLORS[inq.status]?.color || '#ddd',
+                                                    bgcolor: STATUS_COLORS[inq.status]?.bgcolor || '#2a2a2a',
+                                                    border: `1px solid ${STATUS_COLORS[inq.status]?.border || '#3a3a3a'}`,
+                                                    borderRadius: 1,
+                                                    '& .MuiSelect-select': { py: 0.5, px: 1.5 },
+                                                    '& fieldset': { border: 'none' },
+                                                    '& .MuiSvgIcon-root': { color: STATUS_COLORS[inq.status]?.color || '#ddd' },
+                                                }}
+                                                MenuProps={{ PaperProps: { sx: { bgcolor: '#1e1e1e' } } }}
+                                            >
+                                                <MenuItem value="pending" sx={{ color: '#66bb6a' }}>pending</MenuItem>
+                                                <MenuItem value="contacted" sx={{ color: '#4fc3f7' }}>contacted</MenuItem>
+                                                <MenuItem value="closed" sx={{ color: '#888' }}>closed</MenuItem>
+                                            </Select>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Typography variant="caption" sx={{ color: '#777', whiteSpace: 'nowrap' }}>
+                                            {new Date(inq.created_at).toLocaleDateString('en-US', {
+                                                month: 'short', day: 'numeric', year: 'numeric',
+                                            })}
+                                        </Typography>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            )}
+        </Box>
+    );
+};
+
+export default InquiryList;

--- a/src/components/admin/shared/DashboardHeader.jsx
+++ b/src/components/admin/shared/DashboardHeader.jsx
@@ -27,6 +27,7 @@ import {
   DesignServicesIcon,
   HandshakeIcon,
   TrendingUpIcon,
+  ExploreIcon,
 } from './icons';
 import MenuIcon from '@mui/icons-material/Menu';
 import useDeviceDetection from '../../../hooks/useDeviceDetection';
@@ -60,6 +61,7 @@ const DashboardHeader = () => {
     { text: 'Clients', icon: <PeopleIcon />, path: '/admin/users' },
     { text: 'Suppliers', icon: <HandshakeIcon />, path: '/admin/suppliers' },
     { text: 'Investments', icon: <TrendingUpIcon />, path: '/admin/investments' },
+    { text: 'Experiences', icon: <ExploreIcon />, path: '/admin/experiences' },
   ];
 
   // Contenido del drawer para móviles

--- a/src/components/admin/shared/icons.js
+++ b/src/components/admin/shared/icons.js
@@ -10,6 +10,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import DesignServicesIcon from '@mui/icons-material/DesignServices';
 import HandshakeIcon from '@mui/icons-material/Handshake';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import ExploreIcon from '@mui/icons-material/Explore';
 
 export {
     DashboardIcon,
@@ -24,4 +25,5 @@ export {
     DesignServicesIcon,
     HandshakeIcon,
     TrendingUpIcon,
+    ExploreIcon,
 };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -38,7 +38,8 @@
       "yachts": "Yachts",
       "apartments": "Apartments",
       "villas": "Villas",
-      "investments": "Investments"
+      "investments": "Investments",
+      "experiences": "Experiences"
     },
     "brand": "Brand",
     "model": "Model",
@@ -186,5 +187,27 @@
       "noInvestments": "No investments available at this time.",
       "loading": "Loading investments...",
       "error": "Error loading investments. Please try again."
+    },
+    "experiences": {
+      "title": "Experiences",
+      "subtitle": "Live unique moments in Miami",
+      "noExperiences": "No experiences available at this time.",
+      "error": "Error loading experiences. Please try again.",
+      "notFound": "Experience not found.",
+      "backToExperiences": "Back to Experiences",
+      "priceOnRequest": "Price on request",
+      "viewDetails": "View Details",
+      "capacityPeople": "{{capacity}} people",
+      "inquireTitle": "Check availability",
+      "inquireSuccess": "Inquiry sent! We'll contact you soon.",
+      "inquireError": "Error sending inquiry. Please try again.",
+      "form": {
+        "name": "First name",
+        "lastname": "Last name",
+        "email": "Email",
+        "phone": "Phone (optional)",
+        "submit": "Send inquiry",
+        "sending": "Sending..."
+      }
     }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -38,7 +38,8 @@
       "yachts": "Yates",
       "apartments": "Departamentos",
       "villas": "Villas",
-      "investments": "Inversiones"
+      "investments": "Inversiones",
+      "experiences": "Experiencias"
     },
     "brand": "Marca",
     "model": "Modelo",
@@ -186,5 +187,27 @@
       "noInvestments": "No hay inversiones disponibles en este momento.",
       "loading": "Cargando inversiones...",
       "error": "Error al cargar las inversiones. Por favor, intentá de nuevo."
+    },
+    "experiences": {
+      "title": "Experiencias",
+      "subtitle": "Viví momentos únicos en Miami",
+      "noExperiences": "No hay experiencias disponibles en este momento.",
+      "error": "Error al cargar las experiencias. Por favor, intentá de nuevo.",
+      "notFound": "Experiencia no encontrada.",
+      "backToExperiences": "Volver a Experiencias",
+      "priceOnRequest": "A consultar",
+      "viewDetails": "Ver Detalles",
+      "capacityPeople": "{{capacity}} personas",
+      "inquireTitle": "Consultar disponibilidad",
+      "inquireSuccess": "¡Consulta enviada! Te contactaremos a la brevedad.",
+      "inquireError": "Error al enviar la consulta. Por favor, intentá de nuevo.",
+      "form": {
+        "name": "Nombre",
+        "lastname": "Apellido",
+        "email": "Email",
+        "phone": "Teléfono (opcional)",
+        "submit": "Enviar consulta",
+        "sending": "Enviando..."
+      }
     }
 }

--- a/src/pages/ExperienceDetailPage.jsx
+++ b/src/pages/ExperienceDetailPage.jsx
@@ -1,0 +1,281 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+    Box, Button, Card, CardContent, Chip, CircularProgress,
+    Container, Divider, TextField, Typography, useMediaQuery, useTheme,
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { motion } from 'framer-motion';
+import ExploreIcon from '@mui/icons-material/Explore';
+import GroupIcon from '@mui/icons-material/Group';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import SendIcon from '@mui/icons-material/Send';
+import experienceService from '../services/experienceService';
+import ImageCarousel from '../components/images/ImageCarousel';
+
+const MotionCard = motion.create(Card);
+
+const fieldSx = {
+    '& .MuiOutlinedInput-root': {
+        '& fieldset': { borderColor: '#3a3a3a' },
+        '&:hover fieldset': { borderColor: '#555' },
+        '&.Mui-focused fieldset': { borderColor: '#4fc3f7' },
+    },
+    '& .MuiInputLabel-root': { color: '#777' },
+    '& .MuiInputBase-input': { color: '#fff' },
+};
+
+const emptyInquiry = { name: '', lastname: '', email: '', phone: '' };
+
+const ExperienceDetailPage = () => {
+    const { t } = useTranslation();
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+    const [experience, setExperience] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const [inquiry, setInquiry] = useState(emptyInquiry);
+    const [sending, setSending] = useState(false);
+    const [inquirySuccess, setInquirySuccess] = useState(false);
+    const [inquiryError, setInquiryError] = useState(null);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const data = await experienceService.getById(id);
+                setExperience(data);
+            } catch (err) {
+                setError(err?.response?.status === 404
+                    ? t('experiences.notFound')
+                    : t('experiences.error')
+                );
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
+    }, [id, t]);
+
+    const handleInquiryChange = (e) => {
+        const { name, value } = e.target;
+        setInquiry(prev => ({ ...prev, [name]: value }));
+    };
+
+    const isInquiryValid = () =>
+        inquiry.name.trim() && inquiry.lastname.trim() && inquiry.email.trim();
+
+    const handleInquirySubmit = async (e) => {
+        e.preventDefault();
+        if (!isInquiryValid()) return;
+        setSending(true);
+        setInquiryError(null);
+        try {
+            await experienceService.createInquiry({
+                experience_id: experience.id,
+                name: inquiry.name.trim(),
+                lastname: inquiry.lastname.trim(),
+                email: inquiry.email.trim(),
+                phone: inquiry.phone.trim() || undefined,
+            });
+            setInquirySuccess(true);
+            setInquiry(emptyInquiry);
+        } catch {
+            setInquiryError(t('experiences.inquireError'));
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const formatPrice = (price) =>
+        price === null || price === undefined
+            ? t('experiences.priceOnRequest')
+            : `$${Number(price).toLocaleString('en-US')}`;
+
+    if (loading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }}>
+                <CircularProgress sx={{ color: '#4fc3f7' }} />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Container sx={{ py: 8, textAlign: 'center' }}>
+                <Typography color="error" gutterBottom>{error}</Typography>
+                <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/experiences')}>
+                    {t('experiences.backToExperiences')}
+                </Button>
+            </Container>
+        );
+    }
+
+    if (!experience) return null;
+
+    const images = Array.isArray(experience.images) ? experience.images : [];
+
+    return (
+        <Box sx={{ py: 4, minHeight: '100vh', mt: 8, bgcolor: 'background.default', color: 'text.primary' }}>
+            <Container maxWidth="md">
+                <MotionCard
+                    sx={{ width: '100%', mb: 4, bgcolor: 'background.paper', borderRadius: 2, overflow: 'hidden' }}
+                    initial={{ opacity: 0, y: 50 }}
+                    animate={{ opacity: 1, y: 0, transition: { type: 'spring', stiffness: 100, damping: 15 } }}
+                >
+                    {images.length > 0 && (
+                        <ImageCarousel
+                            images={images}
+                            width="95%"
+                            height={isMobile ? '250px' : '480px'}
+                            objectPosition="center center"
+                        />
+                    )}
+
+                    <CardContent sx={{ p: 4 }}>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+                            {/* Título */}
+                            <Typography variant="h4" fontWeight="bold">
+                                {experience.title}
+                            </Typography>
+
+                            {/* Capacidad y precio */}
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                                {experience.capacity !== null && experience.capacity !== undefined && (
+                                    <Chip
+                                        icon={<GroupIcon />}
+                                        label={t('experiences.capacityPeople', { capacity: experience.capacity })}
+                                        sx={{ bgcolor: '#252525', color: '#ccc', border: '1px solid #333' }}
+                                    />
+                                )}
+                                <Typography variant="h5" fontWeight="bold" sx={{ color: '#4fc3f7' }}>
+                                    {formatPrice(experience.price)}
+                                </Typography>
+                            </Box>
+
+                            {/* Descripción */}
+                            {experience.description && (
+                                <>
+                                    <Divider />
+                                    <Box>
+                                        <Typography variant="h6" fontWeight="bold" gutterBottom>
+                                            {t('services.description')}
+                                        </Typography>
+                                        <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.8 }}>
+                                            {experience.description}
+                                        </Typography>
+                                    </Box>
+                                </>
+                            )}
+
+                            <Divider />
+
+                            {/* Formulario de consulta */}
+                            <Box>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                                    <ExploreIcon sx={{ color: '#4fc3f7' }} />
+                                    <Typography variant="h6" fontWeight="bold">
+                                        {t('experiences.inquireTitle')}
+                                    </Typography>
+                                </Box>
+
+                                {inquirySuccess ? (
+                                    <Box sx={{ textAlign: 'center', py: 3 }}>
+                                        <Typography sx={{ color: '#66bb6a', fontWeight: 600 }}>
+                                            {t('experiences.inquireSuccess')}
+                                        </Typography>
+                                    </Box>
+                                ) : (
+                                    <Box
+                                        component="form"
+                                        onSubmit={handleInquirySubmit}
+                                        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+                                    >
+                                        <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+                                            <TextField
+                                                label={t('experiences.form.name')}
+                                                name="name"
+                                                value={inquiry.name}
+                                                onChange={handleInquiryChange}
+                                                fullWidth
+                                                required
+                                                sx={fieldSx}
+                                            />
+                                            <TextField
+                                                label={t('experiences.form.lastname')}
+                                                name="lastname"
+                                                value={inquiry.lastname}
+                                                onChange={handleInquiryChange}
+                                                fullWidth
+                                                required
+                                                sx={fieldSx}
+                                            />
+                                        </Box>
+                                        <TextField
+                                            label={t('experiences.form.email')}
+                                            name="email"
+                                            type="email"
+                                            value={inquiry.email}
+                                            onChange={handleInquiryChange}
+                                            fullWidth
+                                            required
+                                            sx={fieldSx}
+                                        />
+                                        <TextField
+                                            label={t('experiences.form.phone')}
+                                            name="phone"
+                                            value={inquiry.phone}
+                                            onChange={handleInquiryChange}
+                                            fullWidth
+                                            sx={fieldSx}
+                                        />
+
+                                        {inquiryError && (
+                                            <Typography variant="body2" sx={{ color: '#ef5350' }}>
+                                                {inquiryError}
+                                            </Typography>
+                                        )}
+
+                                        <Button
+                                            type="submit"
+                                            variant="contained"
+                                            size="large"
+                                            disabled={sending || !isInquiryValid()}
+                                            startIcon={sending ? <CircularProgress size={16} color="inherit" /> : <SendIcon />}
+                                            sx={{
+                                                bgcolor: '#4fc3f7',
+                                                color: '#000',
+                                                textTransform: 'none',
+                                                fontWeight: 600,
+                                                alignSelf: { sm: 'flex-start' },
+                                                px: 4,
+                                                '&:hover': { bgcolor: '#0288d1', color: '#fff' },
+                                            }}
+                                        >
+                                            {sending ? t('experiences.form.sending') : t('experiences.form.submit')}
+                                        </Button>
+                                    </Box>
+                                )}
+                            </Box>
+                        </Box>
+                    </CardContent>
+                </MotionCard>
+
+                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                    <Button
+                        variant="contained"
+                        startIcon={<ArrowBackIcon />}
+                        onClick={() => navigate('/experiences')}
+                    >
+                        {t('experiences.backToExperiences')}
+                    </Button>
+                </Box>
+            </Container>
+        </Box>
+    );
+};
+
+export default ExperienceDetailPage;

--- a/src/pages/ExperiencesPage.jsx
+++ b/src/pages/ExperiencesPage.jsx
@@ -1,0 +1,200 @@
+import React, { useEffect } from 'react';
+import {
+    Box, Button, Card, CardContent, CardMedia, Chip,
+    CircularProgress, Container, Grid, Typography,
+} from '@mui/material';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import ExploreIcon from '@mui/icons-material/Explore';
+import GroupIcon from '@mui/icons-material/Group';
+import {
+    fetchAllExperiences,
+    selectAllExperiences,
+    selectExperiencesStatus,
+    selectExperiencesError,
+} from '../redux/experienceSlice';
+
+const MotionCard = motion.create(Card);
+
+const cardVariants = {
+    hidden: { opacity: 0, y: 24 },
+    visible: (i) => ({
+        opacity: 1,
+        y: 0,
+        transition: { delay: i * 0.08, duration: 0.4, ease: 'easeOut' },
+    }),
+};
+
+const ExperiencesPage = () => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const experiences = useSelector(selectAllExperiences);
+    const status = useSelector(selectExperiencesStatus);
+    const error = useSelector(selectExperiencesError);
+
+    useEffect(() => {
+        if (status === 'idle') dispatch(fetchAllExperiences());
+    }, [dispatch, status]);
+
+    const formatPrice = (price) =>
+        price === null || price === undefined
+            ? t('experiences.priceOnRequest')
+            : `$${Number(price).toLocaleString('en-US')}`;
+
+    return (
+        <Box sx={{ minHeight: '100vh', bgcolor: '#0e0e0e', pb: 8 }}>
+            {/* Hero */}
+            <Box
+                sx={{
+                    background: 'linear-gradient(135deg, #0d1b2a 0%, #1b263b 50%, #415a77 100%)',
+                    py: { xs: 6, md: 10 },
+                    textAlign: 'center',
+                    px: 2,
+                }}
+            >
+                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 1.5, mb: 2 }}>
+                    <ExploreIcon sx={{ fontSize: 40, color: '#4fc3f7' }} />
+                    <Typography
+                        variant="h3"
+                        sx={{ fontWeight: 700, color: '#fff', fontSize: { xs: '2rem', md: '3rem' } }}
+                    >
+                        {t('experiences.title')}
+                    </Typography>
+                </Box>
+                <Typography variant="h6" sx={{ color: '#aaa', maxWidth: 600, mx: 'auto', fontWeight: 400 }}>
+                    {t('experiences.subtitle')}
+                </Typography>
+            </Box>
+
+            <Container maxWidth="lg" sx={{ mt: 6 }}>
+                {status === 'loading' && (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
+                        <CircularProgress sx={{ color: '#4fc3f7' }} />
+                    </Box>
+                )}
+
+                {status === 'failed' && (
+                    <Box sx={{ textAlign: 'center', py: 10 }}>
+                        <Typography sx={{ color: '#ef5350' }}>{error || t('experiences.error')}</Typography>
+                    </Box>
+                )}
+
+                {status === 'succeeded' && experiences.length === 0 && (
+                    <Box sx={{ textAlign: 'center', py: 10 }}>
+                        <ExploreIcon sx={{ fontSize: 64, color: '#333', mb: 2 }} />
+                        <Typography sx={{ color: '#666' }}>{t('experiences.noExperiences')}</Typography>
+                    </Box>
+                )}
+
+                {status === 'succeeded' && experiences.length > 0 && (
+                    <Grid container spacing={3}>
+                        {experiences.map((exp, i) => (
+                            <Grid item xs={12} sm={6} md={4} key={exp.id}>
+                                <MotionCard
+                                    custom={i}
+                                    initial="hidden"
+                                    animate="visible"
+                                    variants={cardVariants}
+                                    onClick={() => navigate(`/experiences/${exp.id}`)}
+                                    sx={{
+                                        bgcolor: '#1a1a1a',
+                                        border: '1px solid #2a2a2a',
+                                        borderRadius: 2,
+                                        height: '100%',
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        cursor: 'pointer',
+                                        transition: 'border-color 0.2s, transform 0.2s',
+                                        '&:hover': {
+                                            borderColor: '#4fc3f7',
+                                            transform: 'translateY(-4px)',
+                                        },
+                                    }}
+                                >
+                                    {exp.images?.[0] ? (
+                                        <CardMedia
+                                            component="img"
+                                            height="220"
+                                            image={exp.images[0]}
+                                            alt={exp.title}
+                                            sx={{ objectFit: 'cover' }}
+                                        />
+                                    ) : (
+                                        <Box
+                                            sx={{
+                                                height: 220,
+                                                bgcolor: '#252525',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                            }}
+                                        >
+                                            <ExploreIcon sx={{ fontSize: 48, color: '#333' }} />
+                                        </Box>
+                                    )}
+
+                                    <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                                        <Typography variant="h6" sx={{ color: '#fff', fontWeight: 600, lineHeight: 1.3 }}>
+                                            {exp.title}
+                                        </Typography>
+
+                                        {exp.capacity !== null && exp.capacity !== undefined && (
+                                            <Box sx={{ display: 'flex', gap: 1 }}>
+                                                <Chip
+                                                    icon={<GroupIcon sx={{ fontSize: '16px !important' }} />}
+                                                    label={t('experiences.capacityPeople', { capacity: exp.capacity })}
+                                                    size="small"
+                                                    sx={{ bgcolor: '#252525', color: '#ccc', border: '1px solid #333' }}
+                                                />
+                                            </Box>
+                                        )}
+
+                                        {exp.description && (
+                                            <Typography
+                                                variant="body2"
+                                                sx={{
+                                                    color: '#777',
+                                                    display: '-webkit-box',
+                                                    WebkitLineClamp: 2,
+                                                    WebkitBoxOrient: 'vertical',
+                                                    overflow: 'hidden',
+                                                }}
+                                            >
+                                                {exp.description}
+                                            </Typography>
+                                        )}
+
+                                        <Typography variant="h6" sx={{ color: '#4fc3f7', fontWeight: 700, mt: 'auto', pt: 1 }}>
+                                            {formatPrice(exp.price)}
+                                        </Typography>
+
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            fullWidth
+                                            sx={{
+                                                borderColor: '#4fc3f7',
+                                                color: '#4fc3f7',
+                                                textTransform: 'none',
+                                                fontWeight: 600,
+                                                '&:hover': { borderColor: '#0288d1', color: '#0288d1' },
+                                            }}
+                                            onClick={(e) => { e.stopPropagation(); navigate(`/experiences/${exp.id}`); }}
+                                        >
+                                            {t('experiences.viewDetails')}
+                                        </Button>
+                                    </CardContent>
+                                </MotionCard>
+                            </Grid>
+                        ))}
+                    </Grid>
+                )}
+            </Container>
+        </Box>
+    );
+};
+
+export default ExperiencesPage;

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -21,6 +21,7 @@ const services = [
   { id: 3, nameKey: 'services.types.apartments', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024735/utils/Services/apartment.png', path: '/services/apartments' },
   { id: 4, nameKey: 'services.types.villas', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024225/utils/Services/villa.png', path: '/services/villas' },
   { id: 5, nameKey: 'services.types.investments', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024225/utils/Services/villa.png', path: '/investments' },
+  { id: 6, nameKey: 'services.types.experiences', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024229/utils/Services/yacht.png', path: '/experiences' },
 ];
 
 const MotionGrid = motion.create(Grid);

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -21,7 +21,7 @@ const services = [
   { id: 3, nameKey: 'services.types.apartments', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024735/utils/Services/apartment.png', path: '/services/apartments' },
   { id: 4, nameKey: 'services.types.villas', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024225/utils/Services/villa.png', path: '/services/villas' },
   { id: 5, nameKey: 'services.types.investments', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1780519480/utils/Services/investments.jpg', path: '/investments' },
-  { id: 6, nameKey: 'services.types.experiences', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1732024229/utils/Services/yacht.png', path: '/experiences' },
+  { id: 6, nameKey: 'services.types.experiences', image: 'https://res.cloudinary.com/dbvpwfh07/image/upload/v1780519480/utils/Services/experiences.jpg', path: '/experiences' },
 ];
 
 const MotionGrid = motion.create(Grid);

--- a/src/redux/experienceInquirySlice.js
+++ b/src/redux/experienceInquirySlice.js
@@ -1,0 +1,62 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import experienceService from '../services/experienceService';
+
+export const fetchAllInquiries = createAsyncThunk(
+    'experienceInquiries/fetchAll',
+    async (_, { rejectWithValue }) => {
+        try {
+            return await experienceService.getAllInquiries();
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error fetching inquiries');
+        }
+    }
+);
+
+export const updateInquiryStatus = createAsyncThunk(
+    'experienceInquiries/updateStatus',
+    async ({ id, status }, { rejectWithValue }) => {
+        try {
+            return await experienceService.updateInquiryStatus(id, status);
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error updating inquiry status');
+        }
+    }
+);
+
+const experienceInquirySlice = createSlice({
+    name: 'experienceInquiries',
+    initialState: { inquiries: [], status: 'idle', error: null },
+    reducers: {
+        clearError: (state) => { state.error = null; },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchAllInquiries.pending, (state) => {
+                state.status = 'loading';
+                state.error = null;
+            })
+            .addCase(fetchAllInquiries.fulfilled, (state, action) => {
+                state.status = 'succeeded';
+                state.inquiries = action.payload;
+            })
+            .addCase(fetchAllInquiries.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload;
+            })
+            .addCase(updateInquiryStatus.fulfilled, (state, action) => {
+                const idx = state.inquiries.findIndex(i => i.id === action.payload.id);
+                if (idx !== -1) state.inquiries[idx] = action.payload;
+            })
+            .addCase(updateInquiryStatus.rejected, (state, action) => {
+                state.error = action.payload;
+            });
+    },
+});
+
+export const { clearError: clearInquiryError } = experienceInquirySlice.actions;
+
+export const selectAllInquiries = (state) => state.experienceInquiries.inquiries;
+export const selectInquiriesStatus = (state) => state.experienceInquiries.status;
+export const selectInquiriesError = (state) => state.experienceInquiries.error;
+
+export default experienceInquirySlice.reducer;

--- a/src/redux/experienceSlice.js
+++ b/src/redux/experienceSlice.js
@@ -1,0 +1,97 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import experienceService from '../services/experienceService';
+
+export const fetchAllExperiences = createAsyncThunk(
+    'experiences/fetchAll',
+    async (_, { rejectWithValue }) => {
+        try {
+            return await experienceService.getAll();
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error fetching experiences');
+        }
+    }
+);
+
+export const createExperience = createAsyncThunk(
+    'experiences/create',
+    async (formData, { rejectWithValue }) => {
+        try {
+            return await experienceService.create(formData);
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error creating experience');
+        }
+    }
+);
+
+export const updateExperience = createAsyncThunk(
+    'experiences/update',
+    async ({ id, formData }, { rejectWithValue }) => {
+        try {
+            return await experienceService.update(id, formData);
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error updating experience');
+        }
+    }
+);
+
+export const deleteExperience = createAsyncThunk(
+    'experiences/delete',
+    async (id, { rejectWithValue }) => {
+        try {
+            await experienceService.delete(id);
+            return id;
+        } catch (error) {
+            return rejectWithValue(error?.response?.data?.message || 'Error deleting experience');
+        }
+    }
+);
+
+const experienceSlice = createSlice({
+    name: 'experiences',
+    initialState: { experiences: [], status: 'idle', error: null },
+    reducers: {
+        clearError: (state) => { state.error = null; },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchAllExperiences.pending, (state) => {
+                state.status = 'loading';
+                state.error = null;
+            })
+            .addCase(fetchAllExperiences.fulfilled, (state, action) => {
+                state.status = 'succeeded';
+                state.experiences = action.payload;
+            })
+            .addCase(fetchAllExperiences.rejected, (state, action) => {
+                state.status = 'failed';
+                state.error = action.payload;
+            })
+            .addCase(createExperience.fulfilled, (state, action) => {
+                state.experiences.unshift(action.payload);
+            })
+            .addCase(createExperience.rejected, (state, action) => {
+                state.error = action.payload;
+            })
+            .addCase(updateExperience.fulfilled, (state, action) => {
+                const idx = state.experiences.findIndex(e => e.id === action.payload.id);
+                if (idx !== -1) state.experiences[idx] = action.payload;
+            })
+            .addCase(updateExperience.rejected, (state, action) => {
+                state.error = action.payload;
+            })
+            .addCase(deleteExperience.fulfilled, (state, action) => {
+                state.experiences = state.experiences.filter(e => e.id !== action.payload);
+            })
+            .addCase(deleteExperience.rejected, (state, action) => {
+                state.error = action.payload;
+            });
+    },
+});
+
+export const { clearError } = experienceSlice.actions;
+
+export const selectAllExperiences = (state) => state.experiences.experiences;
+export const selectExperiencesStatus = (state) => state.experiences.status;
+export const selectExperiencesError = (state) => state.experiences.error;
+
+export default experienceSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -9,6 +9,8 @@ import reservationPaymentReducer from './reservationPaymentSlice';
 import summaryReducer from './summarySlice';
 import supplierReducer from './supplierSlice';
 import investmentReducer from './investmentSlice';
+import experienceReducer from './experienceSlice';
+import experienceInquiryReducer from './experienceInquirySlice';
 
 export const store = configureStore({
     reducer: {
@@ -22,6 +24,8 @@ export const store = configureStore({
         summary: summaryReducer,
         suppliers: supplierReducer,
         investments: investmentReducer,
+        experiences: experienceReducer,
+        experienceInquiries: experienceInquiryReducer,
     },
 });
 

--- a/src/services/experienceService.js
+++ b/src/services/experienceService.js
@@ -1,0 +1,45 @@
+import api from '../utils/api';
+
+const experienceService = {
+    getAll: async () => {
+        const res = await api.get('/experiences');
+        return res.data;
+    },
+
+    getById: async (id) => {
+        const res = await api.get(`/experiences/${id}`);
+        return res.data;
+    },
+
+    create: async (formData) => {
+        const res = await api.post('/experiences', formData);
+        return res.data;
+    },
+
+    update: async (id, formData) => {
+        const res = await api.put(`/experiences/${id}`, formData);
+        return res.data;
+    },
+
+    delete: async (id) => {
+        const res = await api.delete(`/experiences/${id}`);
+        return res.data;
+    },
+
+    createInquiry: async (data) => {
+        const res = await api.post('/experiences/inquiries', data);
+        return res.data;
+    },
+
+    getAllInquiries: async () => {
+        const res = await api.get('/experiences/inquiries');
+        return res.data;
+    },
+
+    updateInquiryStatus: async (id, status) => {
+        const res = await api.patch(`/experiences/inquiries/${id}`, { status });
+        return res.data;
+    },
+};
+
+export default experienceService;


### PR DESCRIPTION
## Summary

- Add Experiences public listing page with animated grid and detail page with inline inquiry form
- Add admin panel for Experiences with tabs: CRUD management and Inquiries (pending count badge)
- Add `experienceService`, `experienceSlice`, `experienceInquirySlice` to Redux store
- Add Experiences card to Services public page with definitive Cloudinary image

## Test plan

- [x] `/experiences` — listado público carga y las cards son clickeables
- [x] `/experiences/:id` — detalle muestra imágenes, capacity, precio y formulario de consulta
- [x] Formulario de inquiry envía sin JWT (endpoint público)
- [x] `/admin/experiences` — tab "Experiences" permite crear, editar y eliminar
- [x] `/admin/experiences` — tab "Inquiries" muestra consultas y permite cambiar status
- [x] Card de Experiences aparece en `/services` con la imagen correcta

🤖 Generated with [Claude Code](https://claude.com/claude-code)