### PR TITLE
fix: update supplier payment methods to match API

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -4,15 +4,15 @@ Estado actual del proyecto. Leer al inicio de cada sesión antes de tocar códig
 
 ---
 
-## Estado de ramas (al 2026-06-05)
+## Estado de ramas (al 2026-06-19)
 
 | Rama | Estado |
 |------|--------|
-| `main` | Producción — tiene hasta Investments (PR #35) + Experiences (PR #36) |
-| `development` | Adelanta a `main` con Transfers — pendiente de PR a `main` hasta próximo pago del cliente |
+| `main` | Producción — tiene hasta Transfers (PR #37). Todo el scope entregado |
+| `development` | Al día con `main` |
 | `feature/investments` | Eliminada — mergeada a `main` (PR #35) |
 | `feature/experiences` | Eliminada — mergeada a `main` (PR #36) |
-| `feature/transfers` | Eliminada — mergeada a `development` (2026-06-05) |
+| `feature/transfers` | Eliminada — mergeada a `main` (PR #37, 2026-06-19) |
 
 ---
 
@@ -37,10 +37,10 @@ Estado actual del proyecto. Leer al inicio de cada sesión antes de tocar códig
 - `experience_title === null` en inquiry → consulta general (experience_id fue null)
 - Imagen en Services.jsx: `v1780519480/utils/Services/experiences.jpg`
 
-## Features en `development` (pendiente de `main`)
+## Features en producción (`main`) — scope completo entregado
 
-### Transfers — en `development`, **no en `main`**
-- Se despliega cuando el cliente haga el próximo pago
+### Transfers — en `main` (PR #37, 2026-06-19)
+- Mergeado tras pago del cliente. Pendiente: último pago para cierre del proyecto.
 - Rutas públicas: `/transfers` (form-first), `/transfers/:id` (redirige a `/transfers`)
 - Admin: `/admin/transfers` (tabs: Fleet | Inquiries)
 - Página pública: hero → formulario de inquiry → fleet como referencia secundaria

--- a/src/components/admin/suppliers/SupplierPayoutSection.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutSection.jsx
@@ -30,7 +30,7 @@ const PAYMENT_TERMS_OPTIONS = [
     'Within 1 week after check-out',
     'Upon check-in',
 ];
-const PAYMENT_METHODS = ['wire', 'cash', 'card', 'transfer'];
+const PAYMENT_METHODS = ['cash', 'card', 'transfer', 'paypal', 'zelle', 'stripe', 'other'];
 
 // ─── shared sx helpers ────────────────────────────────────────────────────────
 const sectionLabel = {

--- a/src/components/admin/suppliers/SupplierPayoutView.jsx
+++ b/src/components/admin/suppliers/SupplierPayoutView.jsx
@@ -32,9 +32,12 @@ const USD = (n) => `$${Number(n ?? 0).toFixed(2)}`;
 
 const METHOD_LABELS = {
     cash: 'Cash',
-    wire: 'Wire',
     card: 'Card',
     transfer: 'Transfer',
+    paypal: 'PayPal',
+    zelle: 'Zelle',
+    stripe: 'Stripe',
+    other: 'Other',
 };
 
 // ─── sub-components ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes `wire` and adds `paypal`, `zelle`, `stripe`, and `other` as supplier payment methods in both `SupplierPayoutSection` and `SupplierPayoutView`
- Aligns the front-end options with the API accepted values: `cash`, `card`, `transfer`, `paypal`, `zelle`, `stripe`, `other`

## Test plan

- [x] Abrir una reserva en el admin que tenga un supplier asignado
- [x] Verificar que el select de método de pago muestra: Cash, Card, Transfer, PayPal, Zelle, Stripe, Other
- [x] Verificar que `Wire` ya no aparece
- [x] Registrar un pago con cada método nuevo y confirmar que el backend lo acepta

🤖 Generated with [Claude Code](https://claude.com/claude-code)