### PR TITLE
feat: transfers, supplier history, perf fixes, and PUT→PATCH refactor

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -4,12 +4,12 @@ Estado actual del proyecto. Leer al inicio de cada sesión antes de tocar códig
 
 ---
 
-## Estado de ramas (al 2026-06-19)
+## Estado de ramas (al 2026-06-24)
 
 | Rama | Estado |
 |------|--------|
-| `main` | Producción — tiene hasta Transfers (PR #37). Todo el scope entregado |
-| `development` | Al día con `main` |
+| `main` | Producción — PR #38 mergeado (fix métodos de pago suppliers) |
+| `development` | PR #39 abierto — N+1 fix en payments/reservations, historial de pagos a suppliers, columna Reservation en PaymentsList |
 | `feature/investments` | Eliminada — mergeada a `main` (PR #35) |
 | `feature/experiences` | Eliminada — mergeada a `main` (PR #36) |
 | `feature/transfers` | Eliminada — mergeada a `main` (PR #37, 2026-06-19) |
@@ -82,8 +82,9 @@ Estado actual del proyecto. Leer al inicio de cada sesión antes de tocar códig
 - **FormData + números:** Si no hay file upload, usar JSON. `FormData.append` convierte a string y Zod rechaza `z.number()`
 - **Imágenes:** Campo `images` en `multipart/form-data`, máx 30 archivos. No setear `Content-Type` manualmente
 - **Auth admin:** JWT en `localStorage.adminToken`. Interceptor de `api.js` inyecta el header y maneja 401
-- **Suppliers:** Totales en `assignment.calculated.*` — nunca calcular localmente. `supplier_status` viene del objeto reserva
-- **buildingNames en ReservationList:** Usa service call local (no Redux) — el fetch asíncrono de Redux llega tarde al primer render
+- **Suppliers:** Totales en `assignment.calculated.*` — nunca calcular localmente. `supplier_status` viene del objeto reserva. Métodos de pago válidos: `cash`, `card`, `transfer`, `paypal`, `zelle`, `stripe`, `other` (`wire` eliminado desde 2026-06-23)
+- **Datos de JOIN en normalizers:** Antes de hacer fetches secundarios, verificar si el backend ya incluye el campo en la respuesta principal vía JOIN. `clientName/clientLastname/clientEmail` en `/reservation-payments`, `apartmentName/apartmentAddress` en `/reservations` — todos ya venían del back. Fix: agregar al normalizer y eliminar los fetches secundarios.
+- **buildingNames en ReservationList:** `reservation.apartmentName` viene del JOIN del backend — ya no hace falta fetch secundario de apartments (eliminado en 2026-06-24)
 - **useEffect fetch on-mount:** Nunca poner `array.length` en el dep array para guardar un fetch. Usar siempre `[dispatch]` como dep array.
 - **Paginación de reservas:** `rowsPerPageOptions` es `[5, 10, 20]` — máximo 20 por limitación del API. El localStorage se valida contra este array al inicializar.
 - **Prefijo de teléfono:** Se usa restcountries.com (`/v3.1/all?fields=name,flags,idd`) para obtener países. Default Argentina (+54). En campos opcionales, solo se adjunta el prefijo si el usuario ingresa un número.
@@ -94,6 +95,9 @@ Estado actual del proyecto. Leer al inicio de cada sesión antes de tocar códig
 ---
 
 ## Sesiones anteriores (detalle)
+
+- [2026-06-24](memory/2026-06-24.md) — N+1 fix en PaymentsList y ReservationList, columna Reservation en pagos, historial de pagos a suppliers (`/admin/suppliers/:id`), filas clickeables en SupplierList (PR #39)
+- [2026-06-23](memory/2026-06-23.md) — Fix métodos de pago de suppliers: `wire` → `paypal`, `zelle`, `stripe`, `other` (PR #38)
 
 - [2026-06-04c](memory/2026-06-04c.md) — Paginación server-side en todos los listados admin + fix Listings dropdown (Suspense boundary + DashboardHeader)
 - [2026-06-04b](memory/2026-06-04b.md) — Dead code cleanup (PaymentSummary, updatePaymentStatus), fix PUT reserva (clientId + numberOrZero), estandarización errores API (.error)

--- a/src/hooks/useReservation.js
+++ b/src/hooks/useReservation.js
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import {
     createReservation,
-    updateReservation,
     registerPayment,
     generateReservationPdf,
     sendReservationConfirmation
@@ -18,10 +17,6 @@ export const useReservation = () => {
 
     const handleCreateReservation = (data) => {
         return dispatch(createReservation(data));
-    };
-
-    const handleUpdateReservation = (id, data) => {
-        return dispatch(updateReservation({ id, reservationData: data }));
     };
 
     const handleRegisterPayment = (reservationId, paymentData) => {
@@ -51,7 +46,6 @@ export const useReservation = () => {
         loading,
         error,
         handleCreateReservation,
-        handleUpdateReservation,
         handleRegisterPayment,
         handleGeneratePdf,
         handleSendConfirmation

--- a/src/redux/reservationSlice.js
+++ b/src/redux/reservationSlice.js
@@ -52,26 +52,6 @@ export const createReservation = createAsyncThunk(
     }
 );
 
-export const updateReservation = createAsyncThunk(
-    'reservations/update',
-    async ({ id, reservationData }, { rejectWithValue }) => {
-        try {
-            // Asegurarse de que parkingFee sea un número
-            if (reservationData.parkingFee !== undefined) {
-                // Asegurar que sea un número
-                if (typeof reservationData.parkingFee === 'string') {
-                    reservationData.parkingFee = parseFloat(reservationData.parkingFee);
-                }
-            }
-
-            const data = await reservationService.update(id, reservationData);
-            return data;
-        } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error updating reservation');
-        }
-    }
-);
-
 export const deleteReservation = createAsyncThunk(
     'reservations/delete',
     async (id, { rejectWithValue }) => {
@@ -232,22 +212,6 @@ const reservationSlice = createSlice({
             .addCase(createReservation.fulfilled, (state, action) => {
                 const normalized = normalizeReservationFromApi(action.payload);
                 state.reservations.push(normalized);
-            })
-            // Update
-            .addCase(updateReservation.fulfilled, (state, action) => {
-                const updated = normalizeReservationFromApi(action.payload);
-                const index = state.reservations.findIndex(res => res.id === updated.id);
-                if (index !== -1) {
-                    state.reservations[index] = updated;
-                }
-                if (state.selectedReservation?.id === updated.id) {
-                    state.selectedReservation = updated;
-                }
-            })
-            .addCase(updateReservation.rejected, (state, action) => {
-                state.status = 'failed';
-                state.error = action.payload;
-                state.loading = false;
             })
             // Delete
             .addCase(deleteReservation.fulfilled, (state, action) => {

--- a/src/services/reservationService.js
+++ b/src/services/reservationService.js
@@ -68,7 +68,7 @@ const reservationService = {
             const formattedData = normalizeReservationInput(reservationData, { partial: true });
             const dataToSend = stripUndefined(formattedData);
 
-            const response = await api.put(`/reservations/${id}`, dataToSend);
+            const response = await api.patch(`/reservations/${id}`, dataToSend);
             return response.data;
         } catch (error) {
             console.error("Error in update:", error);


### PR DESCRIPTION
## Summary

- **Transfers feature** — página pública con listado de vehículos y formulario de inquiry; CRUD en admin; slice + service completos
- **Historial de pagos a suppliers** — nueva vista `/admin/suppliers/:id` con detalle del supplier y todos sus pagos históricos; fila completa clickeable en `SupplierList`
- **Fix métodos de pago suppliers** — reemplazado `wire` por `paypal`, `zelle`, `stripe`, `other` para alinear con la API
- **Perf fixes** — eliminados N+1 requests en `PaymentsList` y `ReservationList`; `apartmentName` ahora viene del JOIN del backend en lugar de fetches secundarios; columna Reservation agregada a `PaymentsList`
- **Paginación server-side** — en todos los listados del admin (apartments, experiences, investments, services, reservations)
- **Dead code cleanup** — eliminado `PaymentSummary.jsx`, thunk `updateReservation` y `handleUpdateReservation`; `reservationService.update` cambiado de PUT a PATCH para alinearse con el contrato del backend post-merge
- **Fix `Listings` dropdown** — Suspense boundary en `AdminLayout` para evitar que el dropdown quede vacío en primer render

## Test plan

- [x] Crear y editar una reserva — verificar que PATCH funciona igual que PUT (todos los campos se guardan)
- [x] Entrar a `/admin/suppliers` → click en una fila → ver historial de pagos del supplier
- [x] Registrar un pago a supplier con método `zelle` o `paypal` — no debe rechazar
- [x] Abrir `PaymentsList` — verificar que carga sin requests extra y muestra la columna Reservation
- [x] Abrir `ReservationList` — verificar que `apartmentName` aparece correctamente
- [x] Navegar por transfers públicas y completar un inquiry form
- [x] Verificar paginación en listados admin (reservas, pagos, apartments, etc.)
- [x] Dropdown Listings en el header admin muestra opciones correctamente al primer render

🤖 Generated with [Claude Code](https://claude.com/claude-code)