### PR TITLE
fix: error handling — propagar mensajes reales de API en toda la app

### DIFF
--- a/src/components/admin/auth/AdminLogin.jsx
+++ b/src/components/admin/auth/AdminLogin.jsx
@@ -35,7 +35,7 @@ const AdminLogin = () => {
         navigate(from, { replace: true });
       }
     } catch (error) {
-      setError(error.message || 'User or password incorrect');
+      setError(typeof error === 'string' ? error : (error?.message || 'User or password incorrect'));
       localStorage.removeItem('adminToken');
     } finally {
       setLoading(false);

--- a/src/components/admin/payments/PaymentsForm.jsx
+++ b/src/components/admin/payments/PaymentsForm.jsx
@@ -189,7 +189,7 @@ const PaymentForm = ({ open, onClose }) => {
         } catch (error) {
             setErrors(prev => ({
                 ...prev,
-                submit: error.message || 'Error processing payment'
+                submit: typeof error === 'string' ? error : (error?.message || 'Error processing payment')
             }));
         }
     };

--- a/src/components/admin/payments/PaymentsList.jsx
+++ b/src/components/admin/payments/PaymentsList.jsx
@@ -115,7 +115,7 @@ const PaymentsList = () => {
         } catch (error) {
             setSnackbar({
                 open: true,
-                message: error.message || 'Error deleting payment',
+                message: typeof error === 'string' ? error : (error?.message || 'Error deleting payment'),
                 severity: 'error'
             });
         } finally {

--- a/src/components/admin/reservations/ReservationManagement.jsx
+++ b/src/components/admin/reservations/ReservationManagement.jsx
@@ -68,7 +68,7 @@ const ReservationManagement = () => {
                 } catch (error) {
                     setNotification({
                         open: true,
-                        message: 'Error loading reservation data',
+                        message: typeof error === 'string' ? error : (error?.message || 'Error loading reservation data'),
                         type: 'error'
                     });
                 } finally {
@@ -112,7 +112,7 @@ const ReservationManagement = () => {
             console.error('Error al procesar el formulario:', error);
             setNotification({
                 open: true,
-                message: `Error: ${error.message || 'Failed to save reservation'}`,
+                message: typeof error === 'string' ? error : (error?.message || 'Failed to save reservation'),
                 type: 'error'
             });
         }

--- a/src/components/admin/reservations/sections/PaymentSection.jsx
+++ b/src/components/admin/reservations/sections/PaymentSection.jsx
@@ -120,9 +120,10 @@ const PaymentSection = ({ formData, onChange, onPaymentRegistered, onInitialPaym
             }
 
             success('Payment registered successfully!');
-        } catch (error) {
-            console.error('Error registering payment:', error);
-            error('Error registering payment. Please try again.');
+        } catch (err) {
+            console.error('Error registering payment:', err);
+            const msg = typeof err === 'string' ? err : (err?.message || 'Error registering payment');
+            error(msg);
         } finally {
             setIsLoading(false);
         }

--- a/src/redux/reservationPaymentSlice.js
+++ b/src/redux/reservationPaymentSlice.js
@@ -12,6 +12,9 @@ const initialState = {
 };
 
 // Thunks
+const extractMsg = (error, fallback) =>
+    typeof error === 'string' ? error : (error?.message || fallback);
+
 export const fetchAllPayments = createAsyncThunk(
     'reservationPayments/fetchAll',
     async (filters = {}, { rejectWithValue }) => {
@@ -19,7 +22,7 @@ export const fetchAllPayments = createAsyncThunk(
             const data = await reservationPaymentService.getAllPayments(filters);
             return data;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(extractMsg(error, 'Error fetching payments'));
         }
     }
 );
@@ -31,7 +34,7 @@ export const fetchPaymentById = createAsyncThunk(
             const data = await reservationPaymentService.getPaymentById(id);
             return data;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(extractMsg(error, 'Error fetching payment'));
         }
     }
 );
@@ -43,7 +46,7 @@ export const createPayment = createAsyncThunk(
             const data = await reservationPaymentService.createPayment(paymentData);
             return data;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(extractMsg(error, 'Error creating payment'));
         }
     }
 );
@@ -55,7 +58,7 @@ export const updatePayment = createAsyncThunk(
             const data = await reservationPaymentService.updatePayment(id, paymentData);
             return data;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(extractMsg(error, 'Error updating payment'));
         }
     }
 );
@@ -67,7 +70,7 @@ export const deletePayment = createAsyncThunk(
             await reservationPaymentService.deletePayment(id);
             return id;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(extractMsg(error, 'Error deleting payment'));
         }
     }
 );

--- a/src/redux/reservationSlice.js
+++ b/src/redux/reservationSlice.js
@@ -15,6 +15,9 @@ const initialState = {
     pagination: null,
 };
 
+const extractMsg = (error, fallback) =>
+    typeof error === 'string' ? error : (error?.response?.data?.error || error?.response?.data?.message || error?.message || fallback);
+
 // Thunks para operaciones principales
 export const fetchReservations = createAsyncThunk(
     'reservations/fetchAll',
@@ -23,7 +26,7 @@ export const fetchReservations = createAsyncThunk(
             const data = await reservationService.getAll(filters);
             return data;
         } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error fetching reservations');
+            return rejectWithValue(extractMsg(error, 'Error fetching reservations'));
         }
     }
 );
@@ -35,7 +38,7 @@ export const fetchReservationById = createAsyncThunk(
             const data = await reservationService.getById(id);
             return data;
         } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error fetching reservation');
+            return rejectWithValue(extractMsg(error, 'Error fetching reservation'));
         }
     }
 );
@@ -47,7 +50,7 @@ export const createReservation = createAsyncThunk(
             const data = await reservationService.create(reservationData);
             return data;
         } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error creating reservation');
+            return rejectWithValue(extractMsg(error, 'Error creating reservation'));
         }
     }
 );
@@ -84,7 +87,7 @@ export const registerPayment = createAsyncThunk(
             const response = await reservationService.registerPayment(id, paymentData);
             return response.data;
         } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error registering payment');
+            return rejectWithValue(extractMsg(error, 'Error registering payment'));
         }
     }
 );
@@ -96,7 +99,7 @@ export const fetchReservationPayments = createAsyncThunk(
             const data = await reservationService.getReservationPayments(id);
             return { id, payments: data };
         } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error fetching payments');
+            return rejectWithValue(extractMsg(error, 'Error fetching payments'));
         }
     }
 );
@@ -127,7 +130,7 @@ export const generateReservationPdf = createAsyncThunk(
                 };
             }
         } catch (error) {
-            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || 'Error generating PDF');
+            return rejectWithValue(extractMsg(error, 'Error generating PDF'));
         }
     }
 );

--- a/src/redux/serviceSlice.js
+++ b/src/redux/serviceSlice.js
@@ -6,17 +6,11 @@ import { normalizeServiceItemFromApi } from '../utils/normalizers';
 
 const handleApiError = (error) => {
     if (error.response) {
-        if (error.response.status === 401) {
-            // El interceptor global ya maneja limpieza/redirección
-            throw new Error('Unauthorized: Please log in again.');
-        }
-        const message = error.response.data?.error || error.response.data?.message || 'An error occurred';
-        throw new Error(message);
+        return error.response.data?.error || error.response.data?.message || 'An error occurred';
     } else if (error.request) {
-        throw new Error('No response received from server');
-    } else {
-        throw new Error('Error setting up the request');
+        return 'No response received from server';
     }
+    return error.message || 'Error setting up the request';
 };
 
 export const fetchServices = createAsyncThunk(
@@ -155,7 +149,7 @@ const servicesSlice = createSlice({
             .addCase(fetchServices.rejected, (state, action) => {
                 const { serviceType, error } = action.payload;
                 state.status[serviceType] = 'failed';
-                state.error[serviceType] = error.message;
+                state.error[serviceType] = error;
             })
             .addCase(createService.fulfilled, (state, action) => {
                 const { serviceType, data } = action.payload;
@@ -180,17 +174,17 @@ const servicesSlice = createSlice({
             .addCase(createService.rejected, (state, action) => {
                 const { serviceType, error } = action.payload;
                 state.status[serviceType] = 'failed';
-                state.error[serviceType] = error.message;
+                state.error[serviceType] = error;
             })
             .addCase(updateService.rejected, (state, action) => {
                 const { serviceType, error } = action.payload;
                 state.status[serviceType] = 'failed';
-                state.error[serviceType] = error.message;
+                state.error[serviceType] = error;
             })
             .addCase(deleteService.rejected, (state, action) => {
                 const { serviceType, error } = action.payload;
                 state.status[serviceType] = 'failed';
-                state.error[serviceType] = error.message;
+                state.error[serviceType] = error;
             });
     },
 });

--- a/src/redux/summarySlice.js
+++ b/src/redux/summarySlice.js
@@ -9,7 +9,7 @@ export const generateSummary = createAsyncThunk(
             const response = await summaryService.generateSummary(month, year);
             return response;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(typeof error === 'string' ? error : (error?.message || 'Error'));
         }
     }
 );
@@ -21,7 +21,7 @@ export const fetchSummaryDetails = createAsyncThunk(
             const response = await summaryService.getSummaryDetails(year, month);
             return response;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(typeof error === 'string' ? error : (error?.message || 'Error'));
         }
     }
 );
@@ -33,7 +33,7 @@ export const downloadSummaryPDF = createAsyncThunk(
             await summaryService.downloadSummaryPDF(year, month);
             return { year, month };
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(typeof error === 'string' ? error : (error?.message || 'Error'));
         }
     }
 );
@@ -45,7 +45,7 @@ export const sendSummaryEmail = createAsyncThunk(
             const response = await summaryService.sendSummaryEmail(year, month);
             return response;
         } catch (error) {
-            return rejectWithValue(error.message);
+            return rejectWithValue(typeof error === 'string' ? error : (error?.message || 'Error'));
         }
     }
 );

--- a/src/redux/userSlice.js
+++ b/src/redux/userSlice.js
@@ -8,7 +8,7 @@ export const fetchUsers = createAsyncThunk(
             const data = await userService.getAllUsers(filters);
             return data;
         } catch (error) {
-            return rejectWithValue(error.response?.data || 'Error fetching users');
+            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || error?.message || 'Error fetching users');
         }
     }
 );
@@ -20,7 +20,7 @@ export const fetchUserById = createAsyncThunk(
             const data = await userService.getUserById(id);
             return data;
         } catch (error) {
-            return rejectWithValue(error.response?.data || 'Error fetching user by id');
+            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || error?.message || 'Error fetching user by id');
         }
     }
 );
@@ -32,7 +32,7 @@ export const createUser = createAsyncThunk(
             const data = await userService.createUser(userData);
             return data;
         } catch (error) {
-            return rejectWithValue(error.response?.data || 'Error creating user');
+            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || error?.message || 'Error creating user');
         }
     }
 );
@@ -44,7 +44,7 @@ export const updateUser = createAsyncThunk(
             const response = await userService.updateUser(id, data);
             return response;
         } catch (error) {
-            return rejectWithValue(error.response?.data || 'Error updating user');
+            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || error?.message || 'Error updating user');
         }
     }
 );
@@ -56,7 +56,7 @@ export const deleteUser = createAsyncThunk(
             await userService.deleteUser(id);
             return id;
         } catch (error) {
-            return rejectWithValue(error.response?.data || 'Error deleting user');
+            return rejectWithValue(error.response?.data?.error || error.response?.data?.message || error?.message || 'Error deleting user');
         }
     }
 );


### PR DESCRIPTION
## Summary

- **PUT → PATCH** en `reservationService.update` + eliminación del thunk `updateReservation` (código muerto)
- **Error handling global**: los servicios lanzan strings pero los thunks y componentes accedían a `error.message` → siempre mostraban el fallback genérico
  - `reservationSlice`, `reservationPaymentSlice`: thunks usaban `error.response?.data?.error` sobre un string → reescrito con `extractMsg()`
  - `serviceSlice`: `handleApiError` hacía `throw` en vez de `return` → `rejectWithValue` nunca se ejecutaba → cars/yachts/villas quedaban con skeleton infinito
  - `userSlice`: `rejectWithValue(error.response?.data)` pasaba el objeto completo → React crasheaba al renderizarlo → blank en Clients
  - `summarySlice`: `rejectWithValue(error.message)` sobre strings → `undefined` → blank en Home
  - `PaymentSection`: variable shadowing `catch (error)` pisaba la función `error()` del toast → errores de pago swallowados silenciosamente
  - `ReservationManagement`, `PaymentsForm`, `PaymentsList`, `AdminLogin`: corrección de `typeof error === 'string'`
- **Supplier history**: historial de pagos por proveedor en `/admin/suppliers/:id`, fila completa clickeable en SupplierList
- **Perf fixes**: eliminar N+1 requests en PaymentsList y ReservationList, columna Reservation en pagos
- **Paginación server-side** en todos los listados admin
- **Transfers feature** + fixes varios de sesiones anteriores

## Test plan

- [x] Al llegar al rate limit (429), se muestra el mensaje real en todas las secciones: Reservations, Services (Cars/Yachts/Villas/Apartments), Clients, Home
- [x] Editar una reserva confirma que el PATCH funciona correctamente
- [x] Registrar un pago en una reserva muestra errores de validación reales
- [x] Historial de pagos de suppliers carga en `/admin/suppliers/:id`
- [x] Paginación funciona en Reservations, Payments, Clients, Services

🤖 Generated with [Claude Code](https://claude.com/claude-code)